### PR TITLE
CI: upload integration test artifacts to circle for debugging purposes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,9 @@ jobs:
       - checkout
       - restore_cache:
           key: mvn-cache
-
       - run:
-          name: Build and Package. (without tests)
-          command: mvn package -DskipTests
-
-      - run:
-          name: Run unit tests
-          command: mvn test
+          name: Build
+          command: mvn package
       - store_test_results:
           path: runtime/target/surefire-reports
       - store_test_results:
@@ -46,6 +41,7 @@ jobs:
       - run:
          name: Update Docker to latest
          command: ./.circleci/install-docker.sh
+
       - run:
          name: Login to Docker
          command: docker login -u $DOCKER_USER -p $DOCKER_PASS


### PR DESCRIPTION
Once a job has completed you can inspect the integration test results as circle CI artifacts

![screen shot 2017-09-01 at 10 14 50](https://user-images.githubusercontent.com/966205/29963395-978b7370-8efe-11e7-9e27-86427cde210d.png)
