### PR TITLE
The update script can run on any branch really

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,8 @@ jobs:
       - restore_cache:
           key: mvn-cache
       - run:
-           name: Fix release version
-           command: |
-              if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                  ./.circleci/update-versions.sh
-              fi
+           name: Determine the release version
+           command: ./.circleci/update-versions.sh
       - run:
           name: Build and deploy locally
           command: |


### PR DESCRIPTION
As long as we only push changes when building master, we can actually run the update version script on any branch.

This will fix `test-3` on branches other than master (it only passes on master atm).