### PR TITLE
Drop .m2 cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,6 @@ jobs:
       STAGING_DIR: /tmp/staging-repository
     steps:
       - checkout
-      - restore_cache:
-          key: mvn-cache
       - run:
            name: Determine the release version
            command: ./.circleci/update-versions.sh
@@ -92,7 +90,3 @@ jobs:
               ./.circleci/release.sh
             fi
 
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: mvn-cache


### PR DESCRIPTION
We are spuriously caching an .m2 directory; let's ditch it and look
at the timing.

... It's about 40 seconds extra but it's correct. Let's just go with this.