### PR TITLE
build changes to allow building using j9-ea-181

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.0.0-M1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.0.0-M1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/testing/src/main/java/com/fnproject/fn/testing/FnTestingRule.java
+++ b/testing/src/main/java/com/fnproject/fn/testing/FnTestingRule.java
@@ -74,8 +74,9 @@ public final class FnTestingRule implements TestRule {
         // Internal shared classes required to bridge completer into tests
         addSharedClassPrefix("java.");
         addSharedClassPrefix("javax.");
-
         addSharedClassPrefix("sun.");
+        addSharedClassPrefix("jdk.");
+
         addSharedClass(CompleterClient.class);
         addSharedClass(CompleterClientFactory.class);
         addSharedClass(CompletionId.class);

--- a/testing/src/main/java/com/fnproject/fn/testing/InMemCompleter.java
+++ b/testing/src/main/java/com/fnproject/fn/testing/InMemCompleter.java
@@ -2,6 +2,7 @@ package com.fnproject.fn.testing;
 
 import com.fnproject.fn.api.Headers;
 import com.fnproject.fn.api.flow.*;
+import com.fnproject.fn.api.flow.Flow;
 import com.fnproject.fn.runtime.flow.*;
 import com.sun.net.httpserver.HttpServer;
 import org.apache.commons.io.IOUtils;


### PR DESCRIPTION
This fixes the build under the latest J9 release

Nothing major  - just JavaDoc and Flow
