### PR TITLE
Use stdout for logs in unit tests, so that assertions are not swamped by the test stderr

### DIFF
--- a/runtime/src/test/java/com/fnproject/fn/runtime/FnTestHarness.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/FnTestHarness.java
@@ -268,7 +268,7 @@ public class FnTestHarness implements TestRule {
         PrintStream oldSystemErr = System.err;
         try {
             PrintStream functionOut = new PrintStream(stdOut);
-            PrintStream functionErr = new PrintStream(new TeeOutputStream(stdErr, oldSystemErr));
+            PrintStream functionErr = new PrintStream(new TeeOutputStream(stdErr, oldSystemOut));
             System.setOut(functionErr);
             System.setErr(functionErr);
             exitStatus = new EntryPoint().run(

--- a/testing/src/main/java/com/fnproject/fn/testing/FnTestingRule.java
+++ b/testing/src/main/java/com/fnproject/fn/testing/FnTestingRule.java
@@ -214,7 +214,7 @@ public final class FnTestingRule implements TestRule {
 
         try {
             PrintStream functionOut = new PrintStream(stdOut);
-            PrintStream functionErr = new PrintStream(new TeeOutputStream(stdErr, oldSystemErr));
+            PrintStream functionErr = new PrintStream(new TeeOutputStream(stdErr, oldSystemOut));
             System.setOut(functionErr);
             System.setErr(functionErr);
 


### PR DESCRIPTION
Use stdout for logs in unit tests, so that assertions are not hidden in a wall of text.