### PR TITLE
WIP: Pluggable invokers

### DIFF
--- a/api/src/main/java/com/fnproject/fn/api/InputCoercion.java
+++ b/api/src/main/java/com/fnproject/fn/api/InputCoercion.java
@@ -21,5 +21,5 @@ public interface InputCoercion<T> {
      * @param input          the input event
      * @return               the result of the coercion, if it succeeded
      */
-    Optional<T> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input);
+    Optional<T> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input, MethodWrapper methodWrapper);
 }

--- a/api/src/main/java/com/fnproject/fn/api/MethodWrapper.java
+++ b/api/src/main/java/com/fnproject/fn/api/MethodWrapper.java
@@ -1,0 +1,54 @@
+package com.fnproject.fn.api;
+
+import java.lang.reflect.Method;
+
+/**
+ * Represents a method, similar to {@link Method} but with methods for resolving
+ * parameter and return types that are reified generics.
+ */
+public interface MethodWrapper {
+    /**
+     * Get the target class for the function invocation
+     *
+     * The class from which the wrapper was created, may not necessarily be the declaring class of the method, but a
+     * subclass.
+     *
+     * @return the class the user has configured as the function entrypoint
+     */
+    Class<?> getTargetClass();
+
+    /**
+     * Gets the underlying wrapped {@link Method}
+     *
+     * @return {@link Method} which this class wraps
+     */
+    Method getTargetMethod();
+
+    /**
+     * Get the {@link TypeWrapper} for a parameter specified by {@code index}
+     * @param index    index of the parameter whose type to retrieve
+     * @return the type of the parameter at {@code index}, reified generics will resolve to the reified type
+     *         and not {@link Object}
+     */
+    TypeWrapper getParamType(int index);
+
+    /**
+     * Get the {@link TypeWrapper} for the return type of the method.
+     * @return the return type, reified generics will resolve to the reified type and not {@link Object}
+     */
+    TypeWrapper getReturnType();
+
+    /**
+     * Get the name of the method including the package path built from {@link Class#getCanonicalName()} and
+     * {@link Method#getName()}. e.g. {@code com.fnproject.fn.api.MethodWrapper::getLongName} for this method.
+     *
+     * @return long method name
+     */
+    default String getLongName() {
+        return getTargetClass().getCanonicalName() + "::" + getTargetMethod().getName();
+    }
+
+    default int getParameterCount() {
+        return getTargetMethod().getParameterTypes().length;
+    }
+}

--- a/api/src/main/java/com/fnproject/fn/api/OutputCoercion.java
+++ b/api/src/main/java/com/fnproject/fn/api/OutputCoercion.java
@@ -3,5 +3,5 @@ package com.fnproject.fn.api;
 import java.util.Optional;
 
 public interface OutputCoercion {
-    Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value);
+    Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value);
 }

--- a/api/src/main/java/com/fnproject/fn/api/RuntimeContext.java
+++ b/api/src/main/java/com/fnproject/fn/api/RuntimeContext.java
@@ -1,7 +1,6 @@
 package com.fnproject.fn.api;
 
 
-import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Optional;
 
@@ -12,21 +11,19 @@ import java.util.Optional;
  * of a function; they will not change between multiple invocations of a hot function.
  */
 public interface RuntimeContext {
+    /**
+     * Create an instance of the user specified class on which the target function to invoke is declared.
+     *
+     * @return new instance of class containing the target function
+     */
     Optional<Object> getInvokeInstance();
 
     /**
-     * Get the target class for the function invocation
-     *
-     * @return the class the user has configured as the function entrypoint
-     */
-    Class<?> getTargetClass();
-
-    /**
-     * Get the target method of the function invocation
+     * Get the target method of the user-specified function wrapped in a {@link MethodWrapper}
      *
      * @return the target method of the function invocation
      */
-    Method getTargetMethod();
+    MethodWrapper getMethodWrapper();
 
     /**
      * Get a configuration variable value by key
@@ -44,7 +41,7 @@ public interface RuntimeContext {
     Map<String, String> getConfiguration();
 
     /**
-     * get an attribute from the context.
+     * Get an attribute from the context.
      *
      * @param att  the attribute ID
      * @param type the type of the attribute
@@ -76,5 +73,13 @@ public interface RuntimeContext {
      * @param oc The {@link OutputCoercion} to add
      */
     void addOutputCoercion(OutputCoercion oc);
+
+    /**
+     * Set an {@link FunctionInvoker} for this function. The invoker will override
+     * the built in function invoker, although the cloud threads invoker will still
+     * have precedence so that cloud threads can be used from functions using custom invokers.
+     * @param invoker The {@link FunctionInvoker} to add.
+     */
+     void setInvoker(FunctionInvoker invoker);
 
 }

--- a/api/src/main/java/com/fnproject/fn/api/TypeWrapper.java
+++ b/api/src/main/java/com/fnproject/fn/api/TypeWrapper.java
@@ -1,0 +1,26 @@
+package com.fnproject.fn.api;
+
+/**
+ * Interface representing type information about a method, possibly a parameter or return type.
+ */
+public interface TypeWrapper {
+    /**
+     * Unlike {@link java.lang.reflect.Method}, types (such as parameter types, or return types) are
+     * resolved to a reified type even if they are generic, providing reification is possible.
+     *
+     * For example, take the following classes:
+     * <pre>{@code
+     * class GenericParent&lt;T&gt; {
+     *   public void someMethod(T t) { // do something with t }
+     * }
+     *
+     * class ConcreteClass extends GenericParent&lt;String&gt; { }
+     * }</pre>
+     *
+     * A {@link TypeWrapper} representing the first argument of {@code someMethod} would return {@code String.class}
+     * instead of {@code Object.class}
+     *
+     * @return Reified type
+     */
+    Class<?> getParameterClass();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <mockito.version>2.8.47</mockito.version>
         <assertj-core.version>3.6.2</assertj-core.version>
         <httpcore.version>4.4.6</httpcore.version>
+        <typetools.version>0.5.0</typetools.version>
 
         <system-rules.version>1.16.0</system-rules.version>
         <junit.version>4.12</junit.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -37,6 +37,11 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>typetools</artifactId>
+            <version>${typetools.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>

--- a/runtime/src/main/java/com/fnproject/fn/runtime/DefaultMethodWrapper.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/DefaultMethodWrapper.java
@@ -1,0 +1,52 @@
+package com.fnproject.fn.runtime;
+
+import com.fnproject.fn.api.TypeWrapper;
+import com.fnproject.fn.api.MethodWrapper;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * Wrapper class around {@link java.lang.reflect.Method} to provide type
+ * resolution for methods with generic arguments
+ */
+public class DefaultMethodWrapper implements MethodWrapper {
+    private final Class<?> srcClass;
+    private final Method srcMethod;
+
+    DefaultMethodWrapper(Class<?> srcClass, Method srcMethod) {
+        this.srcClass = srcClass;
+        this.srcMethod = srcMethod;
+    }
+
+    public DefaultMethodWrapper(Class<?> srcClass, String srcMethod) {
+        this.srcClass = srcClass;
+        this.srcMethod = Arrays.stream(srcClass.getMethods())
+                               .filter((m) -> m.getName().equals(srcMethod))
+                               .findFirst()
+                               .orElseThrow(() -> new RuntimeException(new NoSuchMethodException(srcClass.getCanonicalName() + "::" + srcMethod)));
+    }
+
+    @Override
+    public Class<?> getTargetClass() {
+        return srcClass;
+    }
+
+    @Override
+    public Method getTargetMethod() { return srcMethod; }
+
+    @Override
+    public TypeWrapper getParamType(int index) {
+        return new ParameterWrapper(this, index);
+    }
+
+    @Override
+    public TypeWrapper getReturnType() {
+        return new ReturnTypeWrapper(this);
+    }
+
+    @Override
+    public String toString() {
+        return getLongName();
+    }
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/DefaultTypeWrapper.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/DefaultTypeWrapper.java
@@ -1,0 +1,16 @@
+package com.fnproject.fn.runtime;
+
+import com.fnproject.fn.api.TypeWrapper;
+
+public class DefaultTypeWrapper implements TypeWrapper {
+    private final Class<?> cls;
+
+    public DefaultTypeWrapper(Class<?> cls) {
+        this.cls = cls;
+    }
+
+    @Override
+    public Class<?> getParameterClass() {
+        return cls;
+    }
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
@@ -35,9 +35,6 @@ public class EntryPoint {
     }
 
 
-    private List<FunctionInvoker> configuredInvokers = Arrays.asList(new FlowContinuationInvoker(), new MethodFunctionInvoker());
-
-
     /**
      * Entrypoint runner - this executes the whole lifecycle of the fn Java FDK runtime - including multiple invocations in the function for hot functions
      *
@@ -61,7 +58,10 @@ public class EntryPoint {
             final Map<String, String> configFromEnvVars = Collections.unmodifiableMap(excludeInternalConfigAndHeaders(env));
 
             FunctionLoader functionLoader = new FunctionLoader();
-            FunctionRuntimeContext runtimeContext = functionLoader.loadFunction(cls, mth, configFromEnvVars);
+            FunctionRuntimeContext runtimeContext = new FunctionRuntimeContext(functionLoader.loadClass(cls, mth), configFromEnvVars);
+
+            FunctionConfigurer functionConfigurer = new FunctionConfigurer();
+            functionConfigurer.configure(runtimeContext);
 
             String format = env.get("FN_FORMAT");
             EventCodec codec;
@@ -81,15 +81,8 @@ public class EntryPoint {
                         break;
                     }
                     try (InputEvent evt = evtOpt.get()) {
-                        FunctionInvocationContext fic = new FunctionInvocationContext(runtimeContext);
-                        OutputEvent output = null;
-                        for (FunctionInvoker invoker : configuredInvokers) {
-                            Optional<OutputEvent> result = invoker.tryInvoke(fic, evt);
-                            if (result.isPresent()) {
-                                output = result.get();
-                                break;
-                            }
-                        }
+                        FunctionInvocationContext fic = runtimeContext.newInvocationContext();
+                        OutputEvent output = runtimeContext.tryInvoke(evt, fic);
                         if (output == null) {
                             throw new FunctionInputHandlingException("No invoker found for input event");
                         }

--- a/runtime/src/main/java/com/fnproject/fn/runtime/FunctionConfigurer.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/FunctionConfigurer.java
@@ -1,0 +1,89 @@
+package com.fnproject.fn.runtime;
+
+import com.fnproject.fn.api.FnConfiguration;
+import com.fnproject.fn.api.MethodWrapper;
+import com.fnproject.fn.runtime.exception.FunctionConfigurationException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+/**
+ * Loads function entry points based on their class name and method name creating a {@link FunctionRuntimeContext}
+ */
+public class FunctionConfigurer {
+
+    /**
+     * create a function runtime context for a given class and method name
+     *
+     * @param runtimeContext    The runtime context encapsulating the function to be run
+     * @return a new runtime context
+     */
+    public void configure(FunctionRuntimeContext runtimeContext) {
+        validateConfigurationMethods(runtimeContext.getMethodWrapper());
+        applyUserConfigurationMethod(runtimeContext.getMethodWrapper(), runtimeContext);
+    }
+
+    private void validateConfigurationMethods(MethodWrapper function) {
+        // Function configuration methods must have a void return type.
+        Arrays.stream(function.getTargetClass().getMethods())
+                .filter(this::isConfigurationMethod)
+                .filter((m) -> !m.getReturnType().equals(Void.TYPE))
+                .forEach((m) -> {
+                    throw new FunctionConfigurationException("Configuration method '" +
+                            m.getName() +
+                            "' does not have a void return type");
+                });
+
+        // If target method is static, configuration methods cannot be non-static.
+        if (Modifier.isStatic(function.getTargetMethod().getModifiers())) {
+            Arrays.stream(function.getTargetClass().getMethods())
+                    .filter(this::isConfigurationMethod)
+                    .filter((m) -> !(Modifier.isStatic(m.getModifiers())))
+                    .forEach((m) -> {
+                        throw new FunctionConfigurationException("Configuration method '" +
+                                m.getName() +
+                                "' cannot be an instance method if the function method is a static method");
+                    });
+        }
+    }
+
+    private void applyUserConfigurationMethod(MethodWrapper targetClass, FunctionRuntimeContext runtimeContext) {
+
+        Arrays.stream(targetClass.getTargetClass().getMethods())
+                .filter(this::isConfigurationMethod)
+                .sorted(Comparator.<Method>comparingInt((m) -> Modifier.isStatic(m.getModifiers()) ? 0 : 1) // run static methods first
+                        .thenComparing(Comparator.<Method>comparingInt((m) -> { // depth first in implementation
+                            int depth = 0;
+                            Class<?> cc = m.getDeclaringClass();
+                            while (null != cc) {
+                                depth++;
+                                cc = cc.getSuperclass();
+                            }
+                            return depth;
+                        })))
+                .forEach(configMethod -> {
+                    try {
+                        Optional<Object> fnInstance = runtimeContext.getInvokeInstance();
+
+                        // Allow the runtime context parameter to be optional
+                        if (configMethod.getParameterCount() == 0) {
+                            configMethod.invoke(fnInstance.orElse(null));
+                        } else {
+                            configMethod.invoke(fnInstance.orElse(null), runtimeContext);
+                        }
+
+                    } catch ( InvocationTargetException e){
+                        throw new FunctionConfigurationException("Error invoking configuration method: " + configMethod.getName(), e.getCause());
+                    } catch (IllegalAccessException e) {
+                        throw new FunctionConfigurationException("Error invoking configuration method: " + configMethod.getName(), e);
+                    }
+                });
+    }
+
+    private boolean isConfigurationMethod(Method m) {
+        return m.getDeclaredAnnotationsByType(FnConfiguration.class).length > 0 && !m.getDeclaringClass().isInterface();
+    }
+
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/FunctionLoader.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/FunctionLoader.java
@@ -1,32 +1,26 @@
 package com.fnproject.fn.runtime;
 
-import com.fnproject.fn.api.FnConfiguration;
-import com.fnproject.fn.runtime.exception.FunctionConfigurationException;
+import com.fnproject.fn.api.MethodWrapper;
 import com.fnproject.fn.runtime.exception.InvalidFunctionDefinitionException;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
  * Loads function entry points based on their class name and method name creating a {@link FunctionRuntimeContext}
  */
 public class FunctionLoader {
+    private static ClassLoader contextClassLoader = FunctionLoader.class.getClassLoader();
 
-
-    /**
-     * create a function runtime context for a given class and method name
-     *
-     * @param className the class name to load
-     * @param fnName    the function in the class
-     * @return a new runtime context
-     */
-    public FunctionRuntimeContext loadFunction( String className, String fnName, Map<String, String> config) {
+    public MethodWrapper loadClass(String className, String fnName) {
         Class<?> targetClass = loadClass(className);
+        return new DefaultMethodWrapper(targetClass, getTargetMethod(targetClass, fnName));
+    }
 
-        List<Method> namedMethods = findMethodsByName(fnName, targetClass);
+    private Method getTargetMethod(Class<?> targetClass, String method) {
+        List<Method> namedMethods = findMethodsByName(method, targetClass);
 
         if (namedMethods.isEmpty()) {
             String names = Arrays.stream(targetClass.getDeclaredMethods())
@@ -35,89 +29,17 @@ public class FunctionLoader {
                     .filter((name) -> !name.startsWith("$"))
                     .reduce((x, y) -> (x + "," + y)).orElseGet(() -> "");
 
-            throw new InvalidFunctionDefinitionException("Method '" + fnName + "' was not found " +
-                    "in class '" + className + "'. Available functions were: [" + names + "]");
+            throw new InvalidFunctionDefinitionException("Method '" + method + "' was not found " +
+                    "in class '" + targetClass.getCanonicalName() + "'. Available functions were: [" + names + "]");
         }
 
         if (namedMethods.size() > 1) {
-            throw new InvalidFunctionDefinitionException("Multiple methods match name " + fnName + " in " + className + "  matching methods were [" + namedMethods.stream().map(Object::toString).collect(Collectors.joining(",")));
+            throw new InvalidFunctionDefinitionException("Multiple methods match name " + method +
+                    " in " + targetClass.getCanonicalName() +
+                    "  matching methods were [" + namedMethods.stream().map(Object::toString).collect(Collectors.joining(",")));
         }
-        Method targetMethod = namedMethods.get(0);
-
-        validateLoadedFunctionClass(targetClass, targetMethod);
-
-        FunctionRuntimeContext runtimeContext = new FunctionRuntimeContext(targetClass, targetMethod, config);
-
-        applyUserConfigurationMethod(targetClass, runtimeContext);
-
-        return runtimeContext;
+        return namedMethods.get(0);
     }
-
-    private void validateLoadedFunctionClass(Class<?> targetClass, Method targetMethod) {
-        // Function configuration methods must have a void return type.
-        Arrays.stream(targetClass.getMethods())
-                .filter(this::isConfigurationMethod)
-                .filter((m) -> !m.getReturnType().equals(Void.TYPE))
-                .forEach((m) -> {
-                    throw new FunctionConfigurationException("Configuration method '" +
-                            m.getName() +
-                            "' does not have a void return type");
-                });
-
-        // If target method is static, configuration methods cannot be non-static.
-        if (Modifier.isStatic(targetMethod.getModifiers())) {
-            Arrays.stream(targetClass.getMethods())
-                    .filter(this::isConfigurationMethod)
-                    .filter((m) -> !(Modifier.isStatic(m.getModifiers())))
-                    .forEach((m) -> {
-                        throw new FunctionConfigurationException("Configuration method '" +
-                                m.getName() +
-                                "' cannot be an instance method if the function method is a static method");
-                    });
-        }
-    }
-
-    private void applyUserConfigurationMethod(Class<?> targetClass, FunctionRuntimeContext runtimeContext) {
-
-        Arrays.stream(targetClass.getMethods())
-                .filter(this::isConfigurationMethod)
-                .sorted(Comparator.<Method>comparingInt((m) -> Modifier.isStatic(m.getModifiers()) ? 0 : 1) // run static methods first
-                        .thenComparing(Comparator.<Method>comparingInt((m) -> { // depth first in implementation
-                            int depth = 0;
-                            Class<?> cc = m.getDeclaringClass();
-                            while (null != cc) {
-                                depth++;
-                                cc = cc.getSuperclass();
-                            }
-                            return depth;
-                        })))
-                .forEach(configMethod -> {
-                    try {
-                        Optional<Object> fnInstance = runtimeContext.getInvokeInstance();
-
-                        // Allow the runtime context parameter to be optional
-                        if (configMethod.getParameterCount() == 0) {
-                            configMethod.invoke(fnInstance.orElse(null));
-                        } else {
-                            configMethod.invoke(fnInstance.orElse(null), runtimeContext);
-                        }
-
-                    } catch ( InvocationTargetException e){
-                        throw new FunctionConfigurationException("Error invoking configuration method: " + configMethod.getName(), e.getCause());
-
-                    } catch (IllegalAccessException e) {
-                        throw new FunctionConfigurationException("Error invoking configuration method: " + configMethod.getName(), e);
-                    }
-                });
-    }
-
-
-    private boolean isConfigurationMethod(Method m) {
-        return m.getDeclaredAnnotationsByType(FnConfiguration.class).length > 0 && !m.getDeclaringClass().isInterface();
-    }
-
-
-
 
     private List<Method> findMethodsByName(String fnName, Class<?> fnClass) {
         return Arrays.stream(fnClass.getMethods())
@@ -126,8 +48,6 @@ public class FunctionLoader {
                 .filter(m -> !m.isBridge())
                 .collect(Collectors.toList());
     }
-
-
 
     private Class<?> loadClass( String className) {
         Class<?> fnClass;
@@ -138,5 +58,15 @@ public class FunctionLoader {
                     "It's likely that the 'cmd' entry in func.yaml is incorrect.", className));
         }
         return fnClass;
+    }
+
+    /**
+     * Override the classloader used for fn class resolution
+     * Primarily for testing, otherwise the system/default  classloader is used.
+     *
+     * @param loader
+     */
+    public static void setContextClassLoader(ClassLoader loader) {
+        contextClassLoader = loader;
     }
 }

--- a/runtime/src/main/java/com/fnproject/fn/runtime/MethodFunctionInvoker.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/MethodFunctionInvoker.java
@@ -1,16 +1,12 @@
 package com.fnproject.fn.runtime;
 
 
-import com.fnproject.fn.api.FunctionInvoker;
-import com.fnproject.fn.api.InputEvent;
-import com.fnproject.fn.api.InvocationContext;
-import com.fnproject.fn.api.OutputEvent;
+import com.fnproject.fn.api.*;
 import com.fnproject.fn.runtime.exception.FunctionInputHandlingException;
 import com.fnproject.fn.runtime.exception.InternalFunctionInvocationException;
 import com.fnproject.fn.runtime.exception.FunctionOutputHandlingException;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Optional;
 
 /**
@@ -30,42 +26,28 @@ public class MethodFunctionInvoker implements FunctionInvoker {
      */
     @Override
     public Optional<OutputEvent> tryInvoke(InvocationContext ctx, InputEvent evt) throws InternalFunctionInvocationException {
-
-        Object[] userFunctionParams = doInputCoercions(ctx, evt);
-
         FunctionRuntimeContext runtimeContext = (FunctionRuntimeContext) ctx.getRuntimeContext();
-        Method targetMethod = runtimeContext.getTargetMethod();
+        MethodWrapper method = runtimeContext.getMethodWrapper();
+
+        Object[] userFunctionParams = coerceParameters(ctx, method, evt);
+
         Object rawResult;
 
         try {
-            rawResult = targetMethod.invoke(ctx.getRuntimeContext().getInvokeInstance().orElse(null), userFunctionParams);
+            rawResult = method.getTargetMethod().invoke(ctx.getRuntimeContext().getInvokeInstance().orElse(null), userFunctionParams);
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new InternalFunctionInvocationException(e.getCause().getMessage(), e.getCause());
         }
 
-        return doOutputCoercion(ctx, runtimeContext, targetMethod, rawResult);
-
+        return coerceReturnValue(ctx, method, rawResult);
     }
 
-    private Object[] doInputCoercions(InvocationContext ctx, InputEvent evt) {
-
+    protected Object[] coerceParameters(InvocationContext ctx, MethodWrapper targetMethod, InputEvent evt) {
         try {
+            Object[] userFunctionParams = new Object[targetMethod.getParameterCount()];
 
-            FunctionRuntimeContext runtimeContext = (FunctionRuntimeContext) ctx.getRuntimeContext();
-            Method targetMethod = runtimeContext.getTargetMethod();
-            Class<?>[] paramTypes = targetMethod.getParameterTypes();
-
-            Object[] userFunctionParams = new Object[paramTypes.length];
-
-            for (int i = 0; i < userFunctionParams.length; i++) {
-                int param = i;
-                Optional<Object> arg = runtimeContext.getInputCoercions(targetMethod, param)
-                        .stream()
-                        .map((c) -> c.tryCoerceParam(ctx, param, evt))
-                        .filter(Optional::isPresent)
-                        .map(Optional::get).findFirst();
-
-                userFunctionParams[i] = arg.orElseThrow(() -> new FunctionInputHandlingException("No type coercion for argument " + param + " of " + targetMethod + " of found"));
+            for (int paramIndex = 0; paramIndex < userFunctionParams.length; paramIndex++) {
+                userFunctionParams[paramIndex] = coerceParameter(ctx, targetMethod, paramIndex, evt);
             }
 
             return userFunctionParams;
@@ -73,16 +55,26 @@ public class MethodFunctionInvoker implements FunctionInvoker {
         } catch (RuntimeException e) {
             throw new FunctionInputHandlingException("An exception was thrown during Input Coercion: " + e.getMessage(), e);
         }
-
     }
 
 
-    private Optional<OutputEvent> doOutputCoercion(InvocationContext ctx, FunctionRuntimeContext runtimeContext, Method targetMethod, Object rawResult) {
+    private Object coerceParameter(InvocationContext ctx, MethodWrapper targetMethod, int param, InputEvent evt) {
+        FunctionRuntimeContext runtimeContext = (FunctionRuntimeContext) ctx.getRuntimeContext();
 
+        return runtimeContext.getInputCoercions(targetMethod, param)
+                .stream()
+                .map((c) -> c.tryCoerceParam(ctx, param, evt, targetMethod))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst()
+                .orElseThrow(() -> new FunctionInputHandlingException("No type coercion for argument " + param + " of " + targetMethod + " of found"));
+    }
+
+    protected Optional<OutputEvent> coerceReturnValue(InvocationContext ctx, MethodWrapper method, Object rawResult) {
         try {
-            return Optional.of(runtimeContext.getOutputCoercions(targetMethod)
+            return Optional.of(((FunctionRuntimeContext) ctx.getRuntimeContext()).getOutputCoercions(method.getTargetMethod())
                     .stream()
-                    .map((c) -> c.wrapFunctionResult(ctx, rawResult))
+                    .map((c) -> c.wrapFunctionResult(ctx, method, rawResult))
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .findFirst()

--- a/runtime/src/main/java/com/fnproject/fn/runtime/MethodTypeWrapper.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/MethodTypeWrapper.java
@@ -1,0 +1,38 @@
+package com.fnproject.fn.runtime;
+
+import com.fnproject.fn.api.TypeWrapper;
+import com.fnproject.fn.api.MethodWrapper;
+import net.jodah.typetools.TypeResolver;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+public class MethodTypeWrapper implements TypeWrapper {
+    protected final MethodWrapper src;
+    protected Class<?> parameterClass;
+
+    public MethodTypeWrapper(MethodWrapper src, Class<?> parameterClass) {
+        this.src = src;
+        this.parameterClass = parameterClass;
+    }
+
+    @Override
+    public Class<?> getParameterClass() {
+        return parameterClass;
+    }
+
+    protected static Class<?> resolveType(Type type, MethodWrapper src) {
+        if (type instanceof Class) {
+            return PrimitiveTypeResolver.resolve((Class<?>) type);
+        } else if (type instanceof ParameterizedType) {
+            return (Class<?>) ((ParameterizedType) type).getRawType();
+        }
+        Class<?> resolvedType = TypeResolver.resolveRawArgument(type, src.getTargetClass());
+        if (resolvedType == TypeResolver.Unknown.class) {
+            // TODO: Decide what exception to throw here
+            throw new RuntimeException("Cannot infer type of method parameter");
+        } else {
+            return resolvedType;
+        }
+    }
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/ParameterWrapper.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/ParameterWrapper.java
@@ -1,0 +1,15 @@
+package com.fnproject.fn.runtime;
+
+import com.fnproject.fn.api.MethodWrapper;
+
+class ParameterWrapper extends MethodTypeWrapper {
+
+    ParameterWrapper(MethodWrapper src, int index) {
+        super(src, resolveType(src.getTargetMethod().getGenericParameterTypes()[index], src));
+    }
+
+    @Override
+    public Class<?> getParameterClass() {
+        return parameterClass;
+    }
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/PrimitiveTypeResolver.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/PrimitiveTypeResolver.java
@@ -1,0 +1,29 @@
+package com.fnproject.fn.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PrimitiveTypeResolver {
+    private static Map<Class<?>, Class<?>> boxedTypes = new HashMap<>();
+    static {
+        boxedTypes.put(void.class, Void.class);
+        boxedTypes.put(boolean.class, Boolean.class);
+        boxedTypes.put(byte.class, Byte.class);
+        boxedTypes.put(char.class, Character.class);
+        boxedTypes.put(short.class, Short.class);
+        boxedTypes.put(int.class, Integer.class);
+        boxedTypes.put(long.class, Long.class);
+        boxedTypes.put(float.class, Float.class);
+        boxedTypes.put(double.class, Double.class);
+    }
+
+    /**
+     * Resolves cls from a possibly primitive class to a boxed type otherwise just returns cls
+     */
+    public static Class<?> resolve(Class<?> cls) {
+        if (cls.isPrimitive()) {
+            return boxedTypes.get(cls);
+        }
+        return cls;
+    }
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/ReturnTypeWrapper.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/ReturnTypeWrapper.java
@@ -1,0 +1,11 @@
+package com.fnproject.fn.runtime;
+
+import com.fnproject.fn.api.MethodWrapper;
+
+class ReturnTypeWrapper extends MethodTypeWrapper {
+
+    ReturnTypeWrapper(MethodWrapper src) {
+        super(src, resolveType(src.getTargetMethod().getGenericReturnType(), src));
+    }
+
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/coercion/ByteArrayCoercion.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/coercion/ByteArrayCoercion.java
@@ -12,8 +12,8 @@ import java.util.Optional;
  */
 public class ByteArrayCoercion implements InputCoercion<byte[]>, OutputCoercion {
     @Override
-    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value) {
-        if (ctx.getRuntimeContext().getTargetMethod().getReturnType().equals(byte[].class)) {
+    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value) {
+        if (method.getReturnType().getParameterClass().equals(byte[].class)) {
             return Optional.of(OutputEvent.fromBytes(((byte[]) value), true, "application/octet-stream"));
         } else {
             return Optional.empty();
@@ -21,7 +21,6 @@ public class ByteArrayCoercion implements InputCoercion<byte[]>, OutputCoercion 
     }
 
     private byte[] toByteArray(InputStream is) throws IOException {
-
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         int nRead;
         byte[] data = new byte[1024];
@@ -34,8 +33,8 @@ public class ByteArrayCoercion implements InputCoercion<byte[]>, OutputCoercion 
     }
 
     @Override
-    public Optional<byte[]> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input) {
-        if (currentContext.getRuntimeContext().getTargetMethod().getParameterTypes()[arg].equals(byte[].class)) {
+    public Optional<byte[]> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input, MethodWrapper method) {
+        if (method.getParamType(arg).getParameterClass().equals(byte[].class)) {
             return Optional.of(
                     input.consumeBody(is -> {
                         try {

--- a/runtime/src/main/java/com/fnproject/fn/runtime/coercion/InputEventCoercion.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/coercion/InputEventCoercion.java
@@ -4,14 +4,15 @@ package com.fnproject.fn.runtime.coercion;
 import com.fnproject.fn.api.InputCoercion;
 import com.fnproject.fn.api.InputEvent;
 import com.fnproject.fn.api.InvocationContext;
+import com.fnproject.fn.api.MethodWrapper;
 
 import java.util.Optional;
 
 public class InputEventCoercion implements InputCoercion<InputEvent> {
 
     @Override
-    public Optional<InputEvent> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input) {
-        if (currentContext.getRuntimeContext().getTargetMethod().getParameterTypes()[arg].equals(InputEvent.class)) {
+    public Optional<InputEvent> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input, MethodWrapper method) {
+        if (method.getParamType(arg).getParameterClass().equals(InputEvent.class)) {
             return Optional.of(input);
         } else {
             return Optional.empty();

--- a/runtime/src/main/java/com/fnproject/fn/runtime/coercion/OutputEventCoercion.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/coercion/OutputEventCoercion.java
@@ -1,6 +1,7 @@
 package com.fnproject.fn.runtime.coercion;
 
 import com.fnproject.fn.api.InvocationContext;
+import com.fnproject.fn.api.MethodWrapper;
 import com.fnproject.fn.api.OutputCoercion;
 import com.fnproject.fn.api.OutputEvent;
 
@@ -8,8 +9,8 @@ import java.util.Optional;
 
 public class OutputEventCoercion implements OutputCoercion {
     @Override
-    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value) {
-        if (ctx.getRuntimeContext().getTargetMethod().getReturnType().equals(OutputEvent.class)) {
+    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value) {
+        if (method.getReturnType().getParameterClass().equals(OutputEvent.class)) {
             return Optional.of((OutputEvent) value);
         } else {
             return Optional.empty();

--- a/runtime/src/main/java/com/fnproject/fn/runtime/coercion/StringCoercion.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/coercion/StringCoercion.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 
 public class StringCoercion implements InputCoercion<String>, OutputCoercion {
     @Override
-    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value) {
-        if (ctx.getRuntimeContext().getTargetMethod().getReturnType().equals(String.class)) {
+    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value) {
+        if (method.getReturnType().getParameterClass().equals(String.class)) {
             return Optional.of(OutputEvent.fromBytes(((String) value).getBytes(), true, "text/plain"));
         } else {
             return Optional.empty();
@@ -18,8 +18,8 @@ public class StringCoercion implements InputCoercion<String>, OutputCoercion {
     }
 
     @Override
-    public Optional<String> tryCoerceParam(InvocationContext currentContext, int param, InputEvent input) {
-        if (currentContext.getRuntimeContext().getTargetMethod().getParameterTypes()[param].equals(String.class)) {
+    public Optional<String> tryCoerceParam(InvocationContext currentContext, int param, InputEvent input, MethodWrapper method) {
+        if (method.getParamType(param).getParameterClass().equals(String.class)) {
             return Optional.of(
                     input.consumeBody(is -> {
                         try {

--- a/runtime/src/main/java/com/fnproject/fn/runtime/coercion/VoidCoercion.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/coercion/VoidCoercion.java
@@ -1,6 +1,7 @@
 package com.fnproject.fn.runtime.coercion;
 
 import com.fnproject.fn.api.InvocationContext;
+import com.fnproject.fn.api.MethodWrapper;
 import com.fnproject.fn.api.OutputCoercion;
 import com.fnproject.fn.api.OutputEvent;
 
@@ -8,8 +9,8 @@ import java.util.Optional;
 
 public class VoidCoercion implements OutputCoercion {
     @Override
-    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value) {
-        if (ctx.getRuntimeContext().getTargetMethod().getReturnType().equals(void.class)) {
+    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value) {
+        if (method.getReturnType().getParameterClass().equals(Void.class)) {
             return Optional.of(OutputEvent.emptyResult(true));
         } else {
             return Optional.empty();

--- a/runtime/src/main/java/com/fnproject/fn/runtime/coercion/jackson/JacksonCoercion.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/coercion/jackson/JacksonCoercion.java
@@ -36,9 +36,10 @@ public class JacksonCoercion implements InputCoercion<Object>, OutputCoercion {
     }
 
     @Override
-    public Optional<Object> tryCoerceParam(InvocationContext currentContext, int param, InputEvent input) {
+    public Optional<Object> tryCoerceParam(InvocationContext currentContext, int param, InputEvent input, MethodWrapper method) {
 
-        Type type = currentContext.getRuntimeContext().getTargetMethod().getGenericParameterTypes()[param];
+        Type type = method.getTargetMethod().getGenericParameterTypes()[param];
+
         JavaType javaType = objectMapper(currentContext).constructType(type);
 
         return Optional.ofNullable(input.consumeBody(inputStream -> {
@@ -48,7 +49,6 @@ public class JacksonCoercion implements InputCoercion<Object>, OutputCoercion {
                 throw coercionFailed(type, e);
             }
         }));
-
     }
 
 
@@ -63,8 +63,7 @@ public class JacksonCoercion implements InputCoercion<Object>, OutputCoercion {
 
 
     @Override
-    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value) {
-
+    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value) {
         try {
             return Optional.of(OutputEvent.fromBytes(objectMapper(ctx).writeValueAsBytes(value), true,
                     "application/json"));
@@ -72,7 +71,5 @@ public class JacksonCoercion implements InputCoercion<Object>, OutputCoercion {
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Failed to render response to JSON", e);
         }
-
     }
-
 }

--- a/runtime/src/main/java/com/fnproject/fn/runtime/exception/InvalidEntryPointException.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/exception/InvalidEntryPointException.java
@@ -1,12 +1,14 @@
 package com.fnproject.fn.runtime.exception;
 
 /**
- * The function entrypoint was malformed .
+ * The function entrypoint was malformed.
  */
 public class InvalidEntryPointException extends FunctionLoadException {
     public InvalidEntryPointException(String msg) {
         super(msg);
     }
 
-
+    public InvalidEntryPointException(String msg, Throwable e) {
+        super(msg, e);
+    }
 }

--- a/runtime/src/test/java/com/fnproject/fn/runtime/ErrorMessagesTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/ErrorMessagesTest.java
@@ -43,13 +43,13 @@ public class ErrorMessagesTest {
     @Test
     public void userSpecifiesClassWithNoMethods(){
         fn.thenRun(ErrorMessages.NoMethodsClass.class, "thisClassHasNoMethods");
-        assertIsErrorWithoutStacktrace("Method 'thisClassHasNoMethods' was not found in class 'com.fnproject.fn.runtime.testfns.ErrorMessages$NoMethodsClass'. Available functions were: []");
+        assertIsErrorWithoutStacktrace("Method 'thisClassHasNoMethods' was not found in class 'com.fnproject.fn.runtime.testfns.ErrorMessages.NoMethodsClass'. Available functions were: []");
     }
 
     @Test
     public void userSpecifiesMethodWhichDoesNotExist(){
         fn.thenRun(ErrorMessages.OneMethodClass.class, "notTheMethod");
-        assertIsErrorWithoutStacktrace("Method 'notTheMethod' was not found in class 'com.fnproject.fn.runtime.testfns.ErrorMessages$OneMethodClass'. Available functions were: [theMethod]");
+        assertIsErrorWithoutStacktrace("Method 'notTheMethod' was not found in class 'com.fnproject.fn.runtime.testfns.ErrorMessages.OneMethodClass'. Available functions were: [theMethod]");
     }
 
     @Test

--- a/runtime/src/test/java/com/fnproject/fn/runtime/JacksonCoercionTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/JacksonCoercionTest.java
@@ -2,6 +2,7 @@ package com.fnproject.fn.runtime;
 
 import com.fnproject.fn.api.Headers;
 import com.fnproject.fn.api.InputEvent;
+import com.fnproject.fn.api.MethodWrapper;
 import com.fnproject.fn.runtime.coercion.jackson.JacksonCoercion;
 import com.fnproject.fn.runtime.testfns.Animal;
 import org.junit.Assert;
@@ -21,7 +22,8 @@ public class JacksonCoercionTest {
     public void listOfCustomObjects() throws NoSuchMethodException {
         JacksonCoercion jc = new JacksonCoercion();
 
-        FunctionRuntimeContext frc = new FunctionRuntimeContext(JacksonCoercionTest.class, JacksonCoercionTest.class.getMethod("testMethod", List.class), new HashMap<>());
+        MethodWrapper method = new DefaultMethodWrapper(JacksonCoercionTest.class, "testMethod");
+        FunctionRuntimeContext frc = new FunctionRuntimeContext(method, new HashMap<>());
         FunctionInvocationContext invocationContext = new FunctionInvocationContext(frc);
 
         Map<String, String> headers = new HashMap<>();
@@ -30,7 +32,7 @@ public class JacksonCoercionTest {
         ByteArrayInputStream body = new ByteArrayInputStream("[{\"name\":\"Spot\",\"age\":6},{\"name\":\"Jason\",\"age\":16}]".getBytes());
         InputEvent inputEvent = new ReadOnceInputEvent("", "", "", "testMethod", body, Headers.fromMap(headers), new QueryParametersImpl());
 
-        Optional<Object> object = jc.tryCoerceParam(invocationContext, 0, inputEvent);
+        Optional<Object> object = jc.tryCoerceParam(invocationContext, 0, inputEvent, method);
 
         List<Animal> animals = (List<Animal>) (object.get());
         Animal first = animals.get(0);
@@ -42,7 +44,8 @@ public class JacksonCoercionTest {
     public void failureToParseIsUserFriendlyError() throws NoSuchMethodException {
         JacksonCoercion jc = new JacksonCoercion();
 
-        FunctionRuntimeContext frc = new FunctionRuntimeContext(JacksonCoercionTest.class, JacksonCoercionTest.class.getMethod("testMethod", List.class), new HashMap<>());
+        MethodWrapper method = new DefaultMethodWrapper(JacksonCoercionTest.class, "testMethod");
+        FunctionRuntimeContext frc = new FunctionRuntimeContext(method, new HashMap<>());
         FunctionInvocationContext invocationContext = new FunctionInvocationContext(frc);
 
         Map<String, String> headers = new HashMap<>();
@@ -53,7 +56,7 @@ public class JacksonCoercionTest {
 
         boolean causedExpectedError;
         try {
-            Optional<Object> object = jc.tryCoerceParam(invocationContext, 0, inputEvent);
+            Optional<Object> object = jc.tryCoerceParam(invocationContext, 0, inputEvent, method);
             causedExpectedError = false;
         } catch (RuntimeException e) {
             causedExpectedError = true;

--- a/runtime/src/test/java/com/fnproject/fn/runtime/MethodWrapperTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/MethodWrapperTest.java
@@ -1,0 +1,98 @@
+package com.fnproject.fn.runtime;
+
+import com.fnproject.fn.api.MethodWrapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class MethodWrapperTest {
+    private final Class srcClass;
+    private final String methodName;
+    private final int parameterIndex;
+    private final Class[] methodParameterTypes;
+    private final Class<?> expectedType;
+
+    public MethodWrapperTest(Class srcClass, String methodName, Class[] methodParameterTypes, int parameterIndex, Class<?> expectedType) throws Exception {
+        this.srcClass = srcClass;
+        this.methodName = methodName;
+        this.parameterIndex = parameterIndex;
+        this.methodParameterTypes = methodParameterTypes;
+        this.expectedType = expectedType;
+    }
+
+    @Test
+    public void testMethodParameterHasExpectedType() throws NoSuchMethodException {
+        MethodWrapper method = new DefaultMethodWrapper(srcClass, srcClass.getMethod(this.methodName, this.methodParameterTypes));
+
+        if (parameterIndex >= 0) {
+            assertThat(method.getParamType(parameterIndex).getParameterClass()).isEqualTo(expectedType);
+        } else {
+            assertThat(parameterIndex).isEqualTo(-1)
+                    .withFailMessage("You can only use non negative parameter indices or -1 to represent return value in this test suite");
+            assertThat(method.getReturnType().getParameterClass()).isEqualTo(expectedType);
+        }
+    }
+
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() throws Exception {
+        return Arrays.asList(new Object[][] {
+                { ConcreteTypeExamples.class, "voidReturnType", new Class[]{ }, -1, Void.class },
+                { ConcreteTypeExamples.class, "singleParameter", new Class[]{ String.class }, 0, String.class },
+                { ConcreteTypeExamples.class, "singlePrimitiveParameter", new Class[]{ boolean.class}, 0, Boolean.class },
+                { ConcreteTypeExamples.class, "singlePrimitiveParameter", new Class[]{ byte.class }, 0, Byte.class },
+                { ConcreteTypeExamples.class, "singlePrimitiveParameter", new Class[]{ char.class }, 0, Character.class },
+                { ConcreteTypeExamples.class, "singlePrimitiveParameter", new Class[]{ short.class }, 0, Short.class },
+                { ConcreteTypeExamples.class, "singlePrimitiveParameter", new Class[]{ int.class }, 0, Integer.class },
+                { ConcreteTypeExamples.class, "singlePrimitiveParameter", new Class[]{ long.class }, 0, Long.class },
+                { ConcreteTypeExamples.class, "singlePrimitiveParameter", new Class[]{ float.class }, 0, Float.class },
+                { ConcreteTypeExamples.class, "singlePrimitiveParameter", new Class[]{ double.class }, 0, Double.class },
+                { ConcreteTypeExamples.class, "multipleParameters", new Class[] { String.class, double.class }, 0, String.class },
+                { ConcreteTypeExamples.class, "multipleParameters", new Class[]{ String.class, double.class }, 1, Double.class },
+                { ConcreteTypeExamples.class, "singleGenericParameter", new Class[]{ List.class }, 0, List.class },
+                { ConcreteTypeExamples.class, "noArgs", new Class[]{}, -1, String.class },
+                { ConcreteTypeExamples.class, "noArgsWithPrimitiveReturnType", new Class[]{}, -1, Integer.class },
+                { ConcreteSubclassOfGenericParent.class, "singleGenericArg", new Class[] { Object.class }, 0, String.class },
+                { ConcreteSubclassOfGenericParent.class, "returnsGeneric", new Class[] { }, -1, String.class },
+                { ConcreteSubclassOfNestedGenericAncestors.class, "methodWithGenericParamAndReturnType", new Class[]{ Object.class }, 0, Integer.class },
+                { ConcreteSubclassOfNestedGenericAncestors.class, "methodWithGenericParamAndReturnType", new Class[]{ Object.class }, -1, String.class }
+        });
+    }
+
+    static class ConcreteTypeExamples {
+        public void voidReturnType() { };
+        public void singleParameter(String s) { };
+        public void singlePrimitiveParameter(boolean i) { };
+        public void singlePrimitiveParameter(byte i) { };
+        public void singlePrimitiveParameter(char i) { };
+        public void singlePrimitiveParameter(short i) { };
+        public void singlePrimitiveParameter(int i) { };
+        public void singlePrimitiveParameter(long i) { };
+        public void singlePrimitiveParameter(float i) { };
+        public void singlePrimitiveParameter(double i) { };
+        public void multipleParameters(String s, double i) { };
+        public String noArgs() { return ""; };
+        public int noArgsWithPrimitiveReturnType() { return 1; };
+        public void singleGenericParameter(List<String> s) { };
+    }
+
+    static class ParentClassWithGenericType<T> {
+        public void singleGenericArg(T t) { };
+        public T returnsGeneric() { return null; };
+    }
+
+    static class ConcreteSubclassOfGenericParent extends ParentClassWithGenericType<String> { }
+
+    static class GenericParent<T, U> {
+        public T methodWithGenericParamAndReturnType(U u) { return null; }
+    }
+    static class SpecialisedGenericParent<T> extends GenericParent<T, Integer> { }
+    static class ConcreteSubclassOfNestedGenericAncestors extends SpecialisedGenericParent<String> { }
+}

--- a/runtime/src/test/java/com/fnproject/fn/runtime/PluggableInvokerTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/PluggableInvokerTest.java
@@ -1,0 +1,37 @@
+package com.fnproject.fn.runtime;
+
+import com.fnproject.fn.api.*;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PluggableInvokerTest {
+
+    @Rule
+    public final FnTestHarness fn = new FnTestHarness();
+
+    @Test
+    public void shouldRunAlternativeEntryPoint() {
+        fn.givenEvent().enqueue();
+
+        fn.thenRun(TestFn.class, "handleRequest");
+        assertThat(fn.getParsedHttpResponses().size()).isEqualTo(1);
+        assertThat(fn.getParsedHttpResponses().get(0).getBodyAsString()).isEqualTo("foo");
+    }
+
+    public static class TestFn {
+        @FnConfiguration
+        public void configure(RuntimeContext ctx) {
+            ctx.setInvoker((ctx1, evt) -> Optional.of(invoke(evt)));
+        }
+
+        public static OutputEvent invoke(InputEvent evt) {
+            return OutputEvent.fromBytes("foo".getBytes(), true, "text/plain");
+        }
+
+        public void handleRequest() {}
+    }
+}

--- a/runtime/src/test/java/com/fnproject/fn/runtime/flow/FlowsContinuationInvokerTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/flow/FlowsContinuationInvokerTest.java
@@ -14,7 +14,6 @@ import org.junit.rules.ExpectedException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.DoubleSupplier;
 
@@ -628,12 +627,7 @@ public class FlowsContinuationInvokerTest {
         }
 
         @Override
-        public Class<?> getTargetClass() {
-            return null;
-        }
-
-        @Override
-        public Method getTargetMethod() {
+        public MethodWrapper getMethodWrapper() {
             return null;
         }
 
@@ -664,6 +658,11 @@ public class FlowsContinuationInvokerTest {
 
         @Override
         public void addOutputCoercion(OutputCoercion oc) {
+            throw new RuntimeException("You can't modify the empty runtime context in the tests, sorry.");
+        }
+
+        @Override
+        public void setInvoker(FunctionInvoker invoker) {
             throw new RuntimeException("You can't modify the empty runtime context in the tests, sorry.");
         }
 

--- a/runtime/src/test/java/com/fnproject/fn/runtime/testfns/coercions/DudCoercion.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/testfns/coercions/DudCoercion.java
@@ -7,12 +7,12 @@ import java.util.Optional;
 public class DudCoercion implements InputCoercion<Object>, OutputCoercion {
 
     @Override
-    public Optional<Object> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input) {
+    public Optional<Object> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input, MethodWrapper method) {
         return Optional.empty();
     }
 
     @Override
-    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value) {
+    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value) {
         return Optional.empty();
     }
 }

--- a/runtime/src/test/java/com/fnproject/fn/runtime/testfns/coercions/StringReversalCoercion.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/testfns/coercions/StringReversalCoercion.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public class StringReversalCoercion implements InputCoercion<String>, OutputCoercion {
     @Override
-    public Optional<String> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input) {
+    public Optional<String> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input, MethodWrapper method) {
         return Optional.of(
                 input.consumeBody(is -> {
                     try {
@@ -22,8 +22,8 @@ public class StringReversalCoercion implements InputCoercion<String>, OutputCoer
     }
 
     @Override
-    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value) {
-        if (ctx.getRuntimeContext().getTargetMethod().getReturnType().equals(String.class)) {
+    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value) {
+        if (ctx.getRuntimeContext().getMethodWrapper().getTargetMethod().getReturnType().equals(String.class)) {
             try {
                 String reversedOutput = new StringBuffer((String) value).reverse().toString();
                 return Optional.of(OutputEvent.fromBytes(reversedOutput.getBytes(), true, "text/plain"));

--- a/runtime/src/test/java/com/fnproject/fn/runtime/testfns/coercions/StringUpperCaseCoercion.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/testfns/coercions/StringUpperCaseCoercion.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public class StringUpperCaseCoercion implements InputCoercion<String>, OutputCoercion {
 
     @Override
-    public Optional<String> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input) {
+    public Optional<String> tryCoerceParam(InvocationContext currentContext, int arg, InputEvent input, MethodWrapper method) {
         return Optional.of(
                 input.consumeBody(is -> {
                     try {
@@ -23,8 +23,8 @@ public class StringUpperCaseCoercion implements InputCoercion<String>, OutputCoe
     }
 
     @Override
-    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, Object value) {
-        if (ctx.getRuntimeContext().getTargetMethod().getReturnType().equals(String.class)) {
+    public Optional<OutputEvent> wrapFunctionResult(InvocationContext ctx, MethodWrapper method, Object value) {
+        if (ctx.getRuntimeContext().getMethodWrapper().getTargetMethod().getReturnType().equals(String.class)) {
             try {
                 String capitilisedOutput = new StringBuffer((String) value).toString().toUpperCase();
                 return Optional.of(OutputEvent.fromBytes(capitilisedOutput.getBytes(), true, "text/plain"));


### PR DESCRIPTION
Will's pluggable invoker piece of work.

There's a problem with this at the moment - the named method (`handleRequest` in `"class.name::handleRequest"`) must exist, even if we're replacing the invoker with something that won't use it.

The reason for this is that MethodWrapper is created early. It's used by the FunctionConfigurer during configuration:

```
        // If target method is static, configuration methods cannot be non-static.
```

There's a verify step prior to a configuration step.

Instead, this should be: If any configuration method is non-static, *then* we reify the methodWrapper and check that its target is non-static but only then.

Configuration could then be split into two parts: static configuration (as before), followed by dynamic invocation. In the latter case, we use getInvokeInstance (which can use the set Invoker) rather than using the methodwrapper directly.


... or something. Essentially, the order of this is not particularly conducive to pluggable invokers which use a different method than the one initially declared.