### PR TITLE
fixes NPE when trying to read from null stream in empty HTTP response

### DIFF
--- a/runtime/src/main/java/com/fnproject/fn/runtime/flow/HttpClient.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/flow/HttpClient.java
@@ -67,7 +67,7 @@ public class HttpClient {
         final int status;
         final Map<String, String> headers = new HashMap<>();
         String statusLine;
-        InputStream body = new ByteArrayInputStream(new byte[]{});
+        InputStream body = new ByteArrayInputStream(new byte[0]);
 
         public HttpResponse(int status) {
             this.status = status;
@@ -118,8 +118,7 @@ public class HttpClient {
         }
 
         public String entityAsString() throws IOException {
-            return IOUtils.toString(body, StandardCharsets.UTF_8);
-
+            return body == null ? null : IOUtils.toString(body, StandardCharsets.UTF_8);
         }
 
         public InputStream getEntity() {
@@ -127,8 +126,7 @@ public class HttpClient {
         }
 
         public byte[] entityAsBytes() throws IOException {
-            return IOUtils.toByteArray(body);
-
+            return body == null ? null : IOUtils.toByteArray(body);
         }
 
         @Override
@@ -143,7 +141,9 @@ public class HttpClient {
 
         @Override
         public void close() throws IOException {
-            body.close();
+            if (body != null) {
+                body.close();
+            }
         }
     }
 

--- a/runtime/src/main/java/com/fnproject/fn/runtime/flow/RemoteCompleterApiClient.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/flow/RemoteCompleterApiClient.java
@@ -312,8 +312,9 @@ public class RemoteCompleterApiClient implements CompleterClient {
     private static void validateSuccessful(HttpClient.HttpResponse response) {
         if (!isSuccessful(response)) {
             try {
+                String body = response.entityAsString();
                 throw new PlatformException(String.format("Received unexpected response (%d) from " +
-                        "completer: %s", response.getStatusCode(), response.entityAsString()));
+                        "completer: %s", response.getStatusCode(), body == null ? "Empty body" : body));
             } catch (IOException e) {
                 throw new PlatformException(String.format("Received unexpected response (%d) from " +
                         "completer. Could not read body.", response.getStatusCode()), e);


### PR DESCRIPTION
Check for empty body before converting entity to string/bytes or closing. Added unit test.