### PR TITLE
Read FN_PATH environment variable instead of FN_ROUTE

### DIFF
--- a/runtime/src/main/java/com/fnproject/fn/runtime/DefaultEventCodec.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/DefaultEventCodec.java
@@ -43,7 +43,7 @@ class DefaultEventCodec implements EventCodec {
     public Optional<InputEvent> readEvent() {
         String method = getRequiredEnv("FN_METHOD");
         String appName = getRequiredEnv("FN_APP_NAME");
-        String route = getRequiredEnv("FN_ROUTE");
+        String route = getRequiredEnv("FN_PATH");
         String requestUrl = getRequiredEnv("FN_REQUEST_URL");
 
         Map<String, String> headers = new HashMap<>();

--- a/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
@@ -174,7 +174,7 @@ public class EntryPoint {
      * any headers that were added to env. Headers are identified as being variables prepended with 'HEADER_'.
      */
     private Map<String, String> excludeInternalConfigAndHeaders(Map<String, String> env) {
-        Set<String> nonConfigEnvKeys = new HashSet<>(Arrays.asList("fn_app_name", "fn_route", "fn_method", "fn_request_url",
+        Set<String> nonConfigEnvKeys = new HashSet<>(Arrays.asList("fn_app_name", "fn_path", "fn_method", "fn_request_url",
                 "fn_format", "content-length", "fn_call_id"));
         Map<String, String> config = new HashMap<>();
         for (Map.Entry<String, String> entry : env.entrySet()) {

--- a/runtime/src/main/java/com/fnproject/fn/runtime/HttpEventCodec.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/HttpEventCodec.java
@@ -80,7 +80,7 @@ public class HttpEventCodec implements EventCodec {
             bodyStream = new ByteArrayInputStream(new byte[]{});
         }
         String appName = requiredHeader(req, "fn_app_name");
-        String route = requiredHeader(req, "fn_route");
+        String route = requiredHeader(req, "fn_path");
         String method = requiredHeader(req, "fn_method");
         String requestUrl = requiredHeader(req, "fn_request_url");
 

--- a/runtime/src/test/java/com/fnproject/fn/runtime/DefaultEventCodecTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/DefaultEventCodecTest.java
@@ -31,7 +31,7 @@ public class DefaultEventCodecTest {
         env.put("FN_FORMAT", "default");
         env.put("FN_METHOD", "GET");
         env.put("FN_APP_NAME", "testapp");
-        env.put("FN_ROUTE", "/route");
+        env.put("FN_PATH", "/route");
         env.put("FN_REQUEST_URL", "http://test.com/fn/tryInvoke");
 
         env.put("FN_HEADER_CONTENT_TYPE", "text/plain");
@@ -69,7 +69,7 @@ public class DefaultEventCodecTest {
     public void shouldRejectMissingEnv() {
         Map<String, String> requiredEnv = new HashMap<>();
 
-        requiredEnv.put("FN_ROUTE", "/route");
+        requiredEnv.put("FN_PATH", "/route");
         requiredEnv.put("FN_METHOD", "GET");
         requiredEnv.put("FN_APP_NAME", "app_name");
         requiredEnv.put("FN_REQUEST_URL", "http://test.com/fn/tryInvoke");

--- a/runtime/src/test/java/com/fnproject/fn/runtime/FnTestHarness.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/FnTestHarness.java
@@ -204,7 +204,7 @@ public class FnTestHarness implements TestRule {
             });
             env.put("FN_METHOD", method);
             env.put("FN_APP_NAME", appName);
-            env.put("FN_ROUTE", route);
+            env.put("FN_PATH", route);
             env.put("FN_REQUEST_URL", requestUrl);
             return env;
         }
@@ -223,7 +223,7 @@ public class FnTestHarness implements TestRule {
             inputString.append(" / HTTP/1.1\r\n");
             inputString.append("Fn_App_name: ").append(appName).append("\r\n");
             inputString.append("Fn_Method: ").append(method).append("\r\n");
-            inputString.append("Fn_Route: ").append(route).append("\r\n");
+            inputString.append("Fn_Path: ").append(route).append("\r\n");
             inputString.append("Fn_Request_url: ").append(requestUrl).append("\r\n");
             if (contentType != null) {
                 inputString.append("Content-Type: ").append(contentType).append("\r\n");

--- a/runtime/src/test/java/com/fnproject/fn/runtime/HttpEventCodecTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/HttpEventCodecTest.java
@@ -28,7 +28,7 @@ public class HttpEventCodecTest {
             "User-Agent: useragent\n" +
             "Accept: text/html, text/plain;q=0.9\n" +
             "Fn_Request_url: http//localhost:8080/r/testapp/test\n" +
-            "Fn_Route: /test\n" +
+            "Fn_Path: /test\n" +
             "Fn_Method: POST\n" +
             "Content-Length: 11\n" +
             "Fn_App_name: testapp\n" +
@@ -42,7 +42,7 @@ public class HttpEventCodecTest {
             "Accept-Encoding: gzip\n" +
             "User-Agent: useragent\n" +
             "Fn_Request_url: http//localhost:8080/r/testapp/test\n" +
-            "Fn_Route: /test2\n" +
+            "Fn_Path: /test2\n" +
             "Fn_Method: GET\n" +
             "Content-Length: 0\n" +
             "Fn_App_name: testapp\n" +
@@ -107,7 +107,7 @@ public class HttpEventCodecTest {
         Map<String, String> requiredHeaders = new HashMap<>();
 
         requiredHeaders.put("fn_request_url", "request_url");
-        requiredHeaders.put("fn_route", "/route");
+        requiredHeaders.put("fn_path", "/route");
         requiredHeaders.put("fn_method", "GET");
         requiredHeaders.put("fn_app_name", "app_name");
 

--- a/testing/src/main/java/com/fnproject/fn/testing/FnHttpEventBuilder.java
+++ b/testing/src/main/java/com/fnproject/fn/testing/FnHttpEventBuilder.java
@@ -140,7 +140,7 @@ class FnHttpEventBuilder {
         headers.forEach((k, v) -> env.put("FN_HEADER_" + k.toUpperCase().replaceAll("-", "_"), v));
         env.put("FN_METHOD", method);
         env.put("FN_APP_NAME", appName);
-        env.put("FN_ROUTE", route);
+        env.put("FN_PATH", route);
         env.put("FN_REQUEST_URL", requestUrl);
         return env;
     }
@@ -155,7 +155,7 @@ class FnHttpEventBuilder {
         inputString.append(" / HTTP/1.1\r\n");
         inputString.append("Fn_App_name: ").append(appName).append("\r\n");
         inputString.append("Fn_Method: ").append(method).append("\r\n");
-        inputString.append("Fn_Route: ").append(route).append("\r\n");
+        inputString.append("Fn_Path: ").append(route).append("\r\n");
         inputString.append("Fn_Request_url: ").append(requestUrl);
         if (!queryParamsFullString.isEmpty()) {
             inputString.append("?").append(queryParamsFullString);


### PR DESCRIPTION
fn as of today supplies FN_PATH instead of FN_ROUTE
As the CLI still calls them routes this patch keeps the public API as route