### PR TITLE
Create named classes for HttpRequest and HttpResponse impls in SerUtils

### DIFF
--- a/api/src/main/java/com/fnproject/fn/api/flow/FunctionInvocationException.java
+++ b/api/src/main/java/com/fnproject/fn/api/flow/FunctionInvocationException.java
@@ -10,7 +10,7 @@ public class FunctionInvocationException extends RuntimeException {
     private final HttpResponse functionResponse;
 
     public FunctionInvocationException(HttpResponse functionResponse) {
-        super(new String(functionResponse.getBodyAsBytes()));
+        super(functionResponse.getBodyAsString());
         this.functionResponse = functionResponse;
     }
 

--- a/api/src/main/java/com/fnproject/fn/api/flow/HttpRequest.java
+++ b/api/src/main/java/com/fnproject/fn/api/flow/HttpRequest.java
@@ -26,4 +26,11 @@ public interface HttpRequest {
      * @return the function request body
      */
     byte[] getBodyAsBytes();
+
+    /**
+     * Returns the body of the request interpreting the body bytes as the bytes of a String
+     *
+     * @return the function response body
+     */
+    String getBodyAsString();
 }

--- a/api/src/main/java/com/fnproject/fn/api/flow/HttpResponse.java
+++ b/api/src/main/java/com/fnproject/fn/api/flow/HttpResponse.java
@@ -27,4 +27,11 @@ public interface HttpResponse {
      * @return the function response body
      */
     byte[] getBodyAsBytes();
+
+    /**
+     * Returns the body of the function result interpreting the body bytes as the bytes of a String
+     *
+     * @return the function response body
+     */
+    String getBodyAsString();
 }

--- a/runtime/src/main/java/com/fnproject/fn/runtime/flow/SerUtils.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/flow/SerUtils.java
@@ -60,6 +60,74 @@ final class SerUtils {
         }
     }
 
+    static final class SerializedHttpRequest implements com.fnproject.fn.api.flow.HttpRequest{
+        private HttpMethod method;
+        private Headers headers;
+        private byte[] body;
+
+        SerializedHttpRequest(HttpMethod method, Headers headers, byte[] body) {
+            this.method = method;
+            this.headers = headers;
+            this.body = body;
+        }
+
+        @Override
+        public HttpMethod getMethod() {
+            return method;
+        }
+
+        @Override
+        public Headers getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public byte[] getBodyAsBytes() {
+            return body;
+        }
+
+        @Override
+        public String toString() {
+            return "SerializedHttpRequest[method=" + method.toString() +
+                    ", headers.getAll().size()=" + headers.getAll().size() +
+                    ", body.length=" + body.length + "]";
+        }
+    }
+
+    static final class SerializedHttpResponse implements com.fnproject.fn.api.flow.HttpResponse {
+        private int statusCode;
+        private Headers headers;
+        private byte[] body;
+
+        SerializedHttpResponse(int statusCode, Headers headers, byte[] body) {
+            this.statusCode = statusCode;
+            this.headers = headers;
+            this.body = body;
+        }
+
+        @Override
+        public int getStatusCode() {
+            return statusCode;
+        }
+
+        @Override
+        public Headers getHeaders() {
+            return headers;
+        }
+
+        @Override
+        public byte[] getBodyAsBytes() {
+            return body;
+        }
+
+        @Override
+        public String toString() {
+            return "SerializedHttpResponse[statusCode=" + statusCode +
+                    ", headers.getAll().size()=" + headers.getAll().size() +
+                    ", body.length=" + body.length + "]";
+        }
+    }
+
     /*
     FnProject-DatumType: blob
     FnProject-DatumType: empty
@@ -154,22 +222,7 @@ final class SerUtils {
             byte[] body = IOUtils.toByteArray(is);
 
             String contentType = h.getHeaderValue(CONTENT_TYPE_HEADER).orElse(null);
-            HttpResponse functionResponse = new HttpResponse() {
-                @Override
-                public int getStatusCode() {
-                    return statusCode;
-                }
-
-                @Override
-                public Headers getHeaders() {
-                    return headers;
-                }
-
-                @Override
-                public byte[] getBodyAsBytes() {
-                    return body;
-                }
-            };
+            HttpResponse functionResponse = new SerializedHttpResponse(statusCode, headers, body);
 
             if (h.getHeaderValue(RESULT_STATUS_HEADER).orElse(RESULT_STATUS_SUCCESS).equalsIgnoreCase(RESULT_STATUS_FAILURE)) {
                 return new ContentPart(dt, contentType, new FunctionInvocationException(functionResponse));
@@ -197,22 +250,7 @@ final class SerUtils {
 
                 String contentType = h.getHeaderValue(CONTENT_TYPE_HEADER).orElse(null);
 
-                com.fnproject.fn.api.flow.HttpRequest req = new com.fnproject.fn.api.flow.HttpRequest() {
-                    @Override
-                    public HttpMethod getMethod() {
-                        return method;
-                    }
-
-                    @Override
-                    public Headers getHeaders() {
-                        return headers;
-                    }
-
-                    @Override
-                    public byte[] getBodyAsBytes() {
-                        return body;
-                    }
-                };
+                com.fnproject.fn.api.flow.HttpRequest req = new SerializedHttpRequest(method, headers, body);
 
                 if (h.getHeaderValue(RESULT_STATUS_HEADER).orElse(RESULT_STATUS_SUCCESS).equalsIgnoreCase(RESULT_STATUS_FAILURE)) {
                     return new ContentPart(dt, contentType, new ExternalCompletionException(req));

--- a/runtime/src/main/java/com/fnproject/fn/runtime/flow/SerUtils.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/flow/SerUtils.java
@@ -87,6 +87,11 @@ final class SerUtils {
         }
 
         @Override
+        public String getBodyAsString() {
+            return new String(getBodyAsBytes());
+        }
+
+        @Override
         public String toString() {
             return "SerializedHttpRequest[method=" + method.toString() +
                     ", headers.getAll().size()=" + headers.getAll().size() +
@@ -118,6 +123,11 @@ final class SerUtils {
         @Override
         public byte[] getBodyAsBytes() {
             return body;
+        }
+
+        @Override
+        public String getBodyAsString() {
+            return new String(getBodyAsBytes());
         }
 
         @Override

--- a/runtime/src/test/java/com/fnproject/fn/runtime/flow/FlowsContinuationInvokerTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/flow/FlowsContinuationInvokerTest.java
@@ -222,7 +222,7 @@ public class FlowsContinuationInvokerTest {
                 .addJavaEntity((Flows.SerFunction<HttpResponse, Boolean>) (result) -> {
                     // Expect
                     assertThat(result.getStatusCode()).isEqualTo(200);
-                    assertThat(new String(result.getBodyAsBytes())).isEqualTo(functionResponse);
+                    assertThat(result.getBodyAsString()).isEqualTo(functionResponse);
                     assertThat(result.getHeaders().get("Custom-Header"))
                             .isPresent()
                             .contains("customValue");
@@ -248,7 +248,7 @@ public class FlowsContinuationInvokerTest {
                 .addJavaEntity((Flows.SerFunction<HttpResponse, Boolean>) (result) -> {
                     // Then
                     assertThat(result.getStatusCode()).isEqualTo(500);
-                    assertThat(new String(result.getBodyAsBytes())).isEqualTo(functionResponse);
+                    assertThat(result.getBodyAsString()).isEqualTo(functionResponse);
                     assertThat(result.getHeaders().get("Custom-Header"))
                             .isPresent()
                             .contains("customValue");
@@ -275,7 +275,7 @@ public class FlowsContinuationInvokerTest {
         String postedResult = "{ \"some\": \"json\" }";
         HttpMultipartSerialization ser = new HttpMultipartSerialization()
                 .addJavaEntity((Flows.SerFunction<Throwable, String>) (result) ->
-                        new String(((FunctionInvocationException) result).getFunctionResponse().getBodyAsBytes()))
+                        ((FunctionInvocationException) result).getFunctionResponse().getBodyAsString())
                 .addFnResultEntity(500, headers, "application/json", postedResult);
 
         InputEvent event = constructContinuationInputEvent(ser);
@@ -298,7 +298,7 @@ public class FlowsContinuationInvokerTest {
                 .addJavaEntity((Flows.SerFunction<HttpRequest, Boolean>) (result) -> {
                     // Expect
                     assertThat(result.getMethod()).isEqualTo(HttpMethod.POST);
-                    assertThat(new String(result.getBodyAsBytes())).isEqualTo(postedResult);
+                    assertThat(result.getBodyAsString()).isEqualTo(postedResult);
                     assertThat(result.getHeaders().get("Content-Type"))
                             .isPresent()
                             .contains("application/json");
@@ -326,7 +326,7 @@ public class FlowsContinuationInvokerTest {
         String postedResult = "{ \"some\": \"json\" }";
         HttpMultipartSerialization ser = new HttpMultipartSerialization()
                 .addJavaEntity((Flows.SerBiFunction<Object, Throwable, String>) (result, error) ->
-                                new String(((ExternalCompletionException) error).getExternalRequest().getBodyAsBytes()))
+                        ((ExternalCompletionException) error).getExternalRequest().getBodyAsString())
                 .addEmptyEntity()
                 .addExternalCompletionEntity("POST", headers, "application/json", postedResult);
 

--- a/testing/src/main/java/com/fnproject/fn/testing/Datum.java
+++ b/testing/src/main/java/com/fnproject/fn/testing/Datum.java
@@ -260,6 +260,11 @@ abstract class Datum {
                 public byte[] getBodyAsBytes() {
                     return body;
                 }
+
+                @Override
+                public String getBodyAsString() {
+                    return new String(body);
+                }
             };
 
         }
@@ -336,6 +341,11 @@ abstract class Datum {
                 @Override
                 public byte[] getBodyAsBytes() {
                     return body;
+                }
+
+                @Override
+                public String getBodyAsString() {
+                    return new String(body);
                 }
             };
         }

--- a/testing/src/test/java/com/fnproject/fn/testing/ExerciseEverything.java
+++ b/testing/src/test/java/com/fnproject/fn/testing/ExerciseEverything.java
@@ -139,7 +139,7 @@ public class ExerciseEverything {
     public FlowFuture<String> checkPassingExternalInvocation(Flow fl) {
         return fl.invokeFunction(inputEvent.getAppName() + inputEvent.getRoute(), HttpMethod.POST, Headers.emptyHeaders(), "PASS".getBytes())
                 .thenApply((resp) -> {
-                    return resp.getStatusCode() != 200 ? "failure" : new String(resp.getBodyAsBytes());
+                    return resp.getStatusCode() != 200 ? "failure" : resp.getBodyAsString();
                 });
     }
 
@@ -347,7 +347,7 @@ public class ExerciseEverything {
                 .withHeader("FnProject-Method", "post")
                 .withBody("bar".getBytes()));
         return cf.thenApply((req) ->
-                req.getHeaders().get("my-header").get() + new String(req.getBodyAsBytes())
+                req.getHeaders().get("my-header").get() + req.getBodyAsString()
         );
     }
 
@@ -397,7 +397,7 @@ public class ExerciseEverything {
                 .exceptionally(e -> {
                             System.err.println("Got into exception with e=" + e);
                             return ((ExternalCompletionException) e).getExternalRequest().getHeaders().get("my-header").get() +
-                                    new String(((ExternalCompletionException) e).getExternalRequest().getBodyAsBytes());
+                                    ((ExternalCompletionException) e).getExternalRequest().getBodyAsString();
                         }
                 );
     }
@@ -557,9 +557,9 @@ public class ExerciseEverything {
         } else if (r instanceof Throwable) {
             return ((Throwable) r).getMessage();
         } else if (r instanceof HttpRequest) {
-            return new String(((HttpRequest) r).getBodyAsBytes());
+            return ((HttpRequest) r).getBodyAsString();
         } else if (r instanceof HttpResponse) {
-            return new String(((HttpResponse) r).getBodyAsBytes());
+            return ((HttpResponse) r).getBodyAsString();
         } else {
             return r.toString();
         }

--- a/testing/src/test/java/com/fnproject/fn/testing/FnTestingRuleFlowsTest.java
+++ b/testing/src/test/java/com/fnproject/fn/testing/FnTestingRuleFlowsTest.java
@@ -438,7 +438,7 @@ public class FnTestingRuleFlowsTest {
         public void invokeFunctionEcho() {
             Flow fl = Flows.currentFlow();
             fl.invokeFunction("user/echo", HttpMethod.GET, Headers.emptyHeaders(), Result.InvokeFunctionEcho.name().getBytes())
-                    .thenAccept((r) -> result = Result.valueOf(new String(r.getBodyAsBytes())));
+                    .thenAccept((r) -> result = Result.valueOf(r.getBodyAsString()));
         }
 
         public static class JSONObject implements  Serializable{


### PR DESCRIPTION
Create package classes for HttpRequest and HttpResponse implementations in SerUtils. This way they can have a sensible `toString` as well.

Also added a `getBodyAsString` method.