### PR TITLE
Make flow objectmapper lazy

### DIFF
--- a/runtime/src/main/java/com/fnproject/fn/runtime/flow/FlowContinuationInvoker.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/flow/FlowContinuationInvoker.java
@@ -31,7 +31,6 @@ public final class FlowContinuationInvoker implements FunctionInvoker {
     private static final String COMPLETER_BASE_URL = "COMPLETER_BASE_URL";
     public static final String FLOW_ID_HEADER = "Fnproject-FlowId";
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private static class URLCompleterClientFactory implements CompleterClientFactory {
         private final String completerBaseUrl;
@@ -110,7 +109,7 @@ public final class FlowContinuationInvoker implements FunctionInvoker {
                 return evt.consumeBody((is) -> {
                     try {
 
-                        APIModel.InvokeStageRequest invokeStageRequest = objectMapper.readValue(is, APIModel.InvokeStageRequest.class);
+                        APIModel.InvokeStageRequest invokeStageRequest = FlowRuntimeGlobals.getObjectMapper().readValue(is, APIModel.InvokeStageRequest.class);
                         HttpClient httpClient = new HttpClient();
                         BlobStoreClient blobClient = ccf.getBlobStoreClient();
 
@@ -266,7 +265,7 @@ public final class FlowContinuationInvoker implements FunctionInvoker {
 
         String json;
         try {
-            json = objectMapper.writeValueAsString(resp);
+            json = FlowRuntimeGlobals.getObjectMapper().writeValueAsString(resp);
         } catch (JsonProcessingException e) {
             throw new PlatformException("Error writing JSON", e);
         }

--- a/runtime/src/main/java/com/fnproject/fn/runtime/flow/FlowRuntimeGlobals.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/flow/FlowRuntimeGlobals.java
@@ -15,13 +15,19 @@ public class FlowRuntimeGlobals {
     private static ObjectMapper objectMapper;
 
 
-
-    public static ObjectMapper getObjectMapper(){
+    /**
+     * Get the default object mapper to use for Flow Invocations
+     *
+     * this will return a runtime-local
+     * @return an initialized objectmapper
+     */
+    public synchronized static ObjectMapper getObjectMapper(){
         if(objectMapper == null){
             objectMapper = new ObjectMapper();
         }
         return objectMapper;
     }
+
     /**
      * Get the current completion ID  - returns an empty optional if the current invocation is not a completion
      *


### PR DESCRIPTION
We still have two OMs (one for Jackson and one for flow) but at least we always create the flow one lazily now. 