### PR TITLE
Adds sensible failure mode for Spring Cloud Function

### DIFF
--- a/api/src/main/java/com/fnproject/fn/api/RuntimeContext.java
+++ b/api/src/main/java/com/fnproject/fn/api/RuntimeContext.java
@@ -77,6 +77,7 @@ public interface RuntimeContext {
      *
      * @param targetMethod The user function method
      * @param param        The index of the parameter
+     * @return  a list of configured input coercions to apply to the given parameter
      */
     List<InputCoercion> getInputCoercions(MethodWrapper targetMethod, int param);
 
@@ -96,6 +97,7 @@ public interface RuntimeContext {
      * coercions second.
      *
      * @param method The user function method
+     * @return a list of configured output coercions to apply to the given method.
      */
     List<OutputCoercion> getOutputCoercions(Method method);
 

--- a/api/src/main/java/com/fnproject/fn/api/exception/FunctionConfigurationException.java
+++ b/api/src/main/java/com/fnproject/fn/api/exception/FunctionConfigurationException.java
@@ -1,4 +1,4 @@
-package com.fnproject.fn.runtime.exception;
+package com.fnproject.fn.api.exception;
 
 /**
  * The function class's configuration methods could not be invoked.

--- a/api/src/main/java/com/fnproject/fn/api/exception/FunctionLoadException.java
+++ b/api/src/main/java/com/fnproject/fn/api/exception/FunctionLoadException.java
@@ -1,7 +1,4 @@
-package com.fnproject.fn.runtime.exception;
-
-
-
+package com.fnproject.fn.api.exception;
 
 /**
  * an exception relating to loading the users code into runtime

--- a/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/SpringCloudFunctionLoader.java
+++ b/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/SpringCloudFunctionLoader.java
@@ -1,5 +1,6 @@
 package com.fnproject.springframework.function;
 
+import com.fnproject.springframework.function.exception.SpringCloudFunctionNotFoundException;
 import com.fnproject.springframework.function.functions.SpringCloudConsumer;
 import com.fnproject.springframework.function.functions.SpringCloudFunction;
 import com.fnproject.springframework.function.functions.SpringCloudMethod;
@@ -15,19 +16,18 @@ import java.util.function.Supplier;
 
 /**
  * The Loader for Spring Cloud Functions
- *
+ * <p>
  * Looks up Functions from the {@link FunctionCatalog} (which is likely populated by your
  * function class, see {@link SpringCloudFunctionInvoker#SpringCloudFunctionInvoker(Class<?>)})
- *
+ * <p>
  * Lookup is in the following order:
- *
+ * <p>
  * Environment variable `FN_SPRING_FUNCTION` returning a `Function`
  * Environment variable `FN_SPRING_CONSUMER` returning a `Consumer`
  * Environment variable `FN_SPRING_SUPPLIER` returning a `Supplier`
  * Bean named `function` returning a `Function`
  * Bean named `consumer` returning a `Consumer`
  * Bean named `supplier` returning a `Supplier`
-
  */
 public class SpringCloudFunctionLoader {
     public static final String DEFAULT_SUPPLIER_BEAN = "supplier";
@@ -44,9 +44,6 @@ public class SpringCloudFunctionLoader {
     private Function<Flux<?>, Flux<?>> function;
     private Consumer<Flux<?>> consumer;
     private Supplier<Flux<?>> supplier;
-    private String functionName;
-    private String supplierName;
-    private String consumerName;
 
     SpringCloudFunctionLoader(@Autowired FunctionCatalog catalog, @Autowired FunctionInspector inspector) {
         this.catalog = catalog;
@@ -54,47 +51,47 @@ public class SpringCloudFunctionLoader {
     }
 
     void loadFunction() {
-        boolean foundName = checkForBeanNameInEnvVars();
-        if (foundName) {
-            if (functionName != null) {
-                function = this.catalog.lookupFunction(functionName);
-            } else if (consumerName != null) {
-                consumer = this.catalog.lookupConsumer(consumerName);
-            } else if (supplierName != null) {
-                supplier = this.catalog.lookupSupplier(supplierName);
-            }
-            // TODO: throw exception if we don't find the specified function?
-            // TODO: throw exception if multiple values are set?
-        } else {
-            function = this.catalog.lookupFunction(DEFAULT_FUNCTION_BEAN);
-            if (function == null) {
-                consumer = this.catalog.lookupConsumer(DEFAULT_CONSUMER_BEAN);
-                if (consumer == null) {
-                    supplier = this.catalog.lookupSupplier(DEFAULT_SUPPLIER_BEAN);
-                }
-            }
+
+        loadSpringCloudFunctionFromEnvVars();
+
+        if (noSpringCloudFunctionFound()) {
+            loadSpringCloudFunctionFromDefaults();
         }
-        // TODO throw exception if no function found?
+
+        if (noSpringCloudFunctionFound()) {
+            throw new SpringCloudFunctionNotFoundException("No Spring Cloud Function found.");
+        }
     }
 
-    private boolean checkForBeanNameInEnvVars() {
+
+    private void loadSpringCloudFunctionFromEnvVars() {
         String functionName = System.getenv(ENV_VAR_FUNCTION_NAME);
         if (functionName != null) {
-            this.functionName = functionName;
-            return true;
+            function = this.catalog.lookupFunction(functionName);
         }
+
         String consumerName = System.getenv(ENV_VAR_CONSUMER_NAME);
         if (consumerName != null) {
-            this.consumerName = consumerName;
-            return true;
+            consumer = this.catalog.lookupConsumer(consumerName);
         }
+
         String supplierName = System.getenv(ENV_VAR_SUPPLIER_NAME);
         if (supplierName != null) {
-            this.supplierName = supplierName;
-            return true;
+            supplier = this.catalog.lookupSupplier(supplierName);
         }
-        return false;
     }
+
+    private void loadSpringCloudFunctionFromDefaults() {
+        function = this.catalog.lookupFunction(DEFAULT_FUNCTION_BEAN);
+        consumer = this.catalog.lookupConsumer(DEFAULT_CONSUMER_BEAN);
+        supplier = this.catalog.lookupSupplier(DEFAULT_SUPPLIER_BEAN);
+    }
+
+
+    private boolean noSpringCloudFunctionFound() {
+        return function == null && consumer == null && supplier == null;
+    }
+
 
     SpringCloudMethod getFunction() {
         if (function != null) {

--- a/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/exception/SpringCloudFunctionNotFoundException.java
+++ b/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/exception/SpringCloudFunctionNotFoundException.java
@@ -1,0 +1,18 @@
+package com.fnproject.springframework.function.exception;
+
+import com.fnproject.fn.api.exception.FunctionLoadException;
+
+/**
+ * Spring Cloud Function integration attempts to find the right Bean to use
+ * as the function entrypoint. This exception is thrown when that fails.
+ */
+public class SpringCloudFunctionNotFoundException extends FunctionLoadException {
+
+    public SpringCloudFunctionNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SpringCloudFunctionNotFoundException(String msg) {
+        super(msg);
+    }
+}

--- a/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/SpringCloudFunctionInvokerIntegrationTest.java
+++ b/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/SpringCloudFunctionInvokerIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.fnproject.springframework.function;
 
+import com.fnproject.fn.testing.FnResult;
 import com.fnproject.fn.testing.FnTestingRule;
+import com.fnproject.springframework.function.testfns.EmptyFunctionConfig;
 import com.fnproject.springframework.function.testfns.FunctionConfig;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +50,19 @@ public class SpringCloudFunctionInvokerIntegrationTest {
 
         String output = fnRule.getOnlyResult().getBodyAsString();
         assertThat(output).isEqualTo("Hello");
+    }
+
+    @Test
+    public void shouldThrowFunctionLoadExceptionIfNoValidFunction() {
+        fnRule.givenEvent().enqueue();
+
+        fnRule.thenRun(EmptyFunctionConfig.class, "handleRequest");
+
+        int exitCode = fnRule.getLastExitCode();
+
+        assertThat(exitCode).isEqualTo(2);
+        assertThat(fnRule.getResults()).isEmpty(); // fails at init so no results.
+        assertThat(fnRule.getStdErrAsString()).contains("No Spring Cloud Function found");
     }
 }
 

--- a/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/testfns/EmptyFunctionConfig.java
+++ b/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/testfns/EmptyFunctionConfig.java
@@ -1,0 +1,24 @@
+package com.fnproject.springframework.function.testfns;
+
+import com.fnproject.fn.api.FnConfiguration;
+import com.fnproject.fn.api.RuntimeContext;
+import com.fnproject.springframework.function.SpringCloudFunctionInvoker;
+import org.springframework.cloud.function.context.ContextFunctionCatalogAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Configuration
+@Import(ContextFunctionCatalogAutoConfiguration.class)
+public class EmptyFunctionConfig {
+    @FnConfiguration
+    public static void configure(RuntimeContext ctx) {
+        ctx.setInvoker(new SpringCloudFunctionInvoker(EmptyFunctionConfig.class));
+    }
+    public void handleRequest() { }
+
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
@@ -4,6 +4,7 @@ package com.fnproject.fn.runtime;
 import com.fnproject.fn.api.InputEvent;
 import com.fnproject.fn.api.OutputEvent;
 import com.fnproject.fn.api.exception.FunctionInputHandlingException;
+import com.fnproject.fn.api.exception.FunctionLoadException;
 import com.fnproject.fn.api.exception.FunctionOutputHandlingException;
 import com.fnproject.fn.runtime.exception.*;
 
@@ -116,6 +117,8 @@ public class EntryPoint {
             // catch all block;
             loggingOutput.println(filterStackTraceToOnlyIncludeUsersCode(e));
             return 2;
+        } catch (Exception ee){
+            ee.printStackTrace();
         }
 
         return lastStatus;

--- a/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
@@ -118,8 +118,8 @@ public class EntryPoint {
             loggingOutput.println(filterStackTraceToOnlyIncludeUsersCode(e));
             return 2;
         } catch (Exception ee){
-            loggingOutput.println("An unexpected error occured:");
-            loggingOutput.println(filterStackTraceToOnlyIncludeUsersCode(ee));
+            loggingOutput.println("An unexpected error occurred:");
+            ee.printStackTrace(loggingOutput);
             return 1;
         }
 

--- a/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
@@ -118,7 +118,9 @@ public class EntryPoint {
             loggingOutput.println(filterStackTraceToOnlyIncludeUsersCode(e));
             return 2;
         } catch (Exception ee){
-            ee.printStackTrace();
+            loggingOutput.println("An unexpected error occured:");
+            loggingOutput.println(filterStackTraceToOnlyIncludeUsersCode(ee));
+            return 1;
         }
 
         return lastStatus;

--- a/runtime/src/main/java/com/fnproject/fn/runtime/FunctionConfigurer.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/FunctionConfigurer.java
@@ -2,7 +2,7 @@ package com.fnproject.fn.runtime;
 
 import com.fnproject.fn.api.FnConfiguration;
 import com.fnproject.fn.api.MethodWrapper;
-import com.fnproject.fn.runtime.exception.FunctionConfigurationException;
+import com.fnproject.fn.api.exception.FunctionConfigurationException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/runtime/src/main/java/com/fnproject/fn/runtime/FunctionLoader.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/FunctionLoader.java
@@ -1,17 +1,11 @@
 package com.fnproject.fn.runtime;
 
-import com.fnproject.fn.api.FnConfiguration;
 import com.fnproject.fn.api.MethodWrapper;
-import com.fnproject.fn.runtime.exception.FunctionConfigurationException;
 import com.fnproject.fn.runtime.exception.InvalidFunctionDefinitionException;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class FunctionLoader {

--- a/runtime/src/main/java/com/fnproject/fn/runtime/FunctionRuntimeContext.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/FunctionRuntimeContext.java
@@ -17,7 +17,7 @@ import com.fnproject.fn.runtime.coercion.StringCoercion;
 import com.fnproject.fn.runtime.coercion.VoidCoercion;
 import com.fnproject.fn.runtime.coercion.jackson.JacksonCoercion;
 import com.fnproject.fn.runtime.exception.FunctionClassInstantiationException;
-import com.fnproject.fn.runtime.exception.FunctionConfigurationException;
+import com.fnproject.fn.api.exception.FunctionConfigurationException;
 import com.fnproject.fn.api.exception.FunctionInputHandlingException;
 import com.fnproject.fn.runtime.flow.FlowContinuationInvoker;
 

--- a/runtime/src/main/java/com/fnproject/fn/runtime/exception/FunctionClassInstantiationException.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/exception/FunctionClassInstantiationException.java
@@ -1,5 +1,7 @@
 package com.fnproject.fn.runtime.exception;
 
+import com.fnproject.fn.api.exception.FunctionLoadException;
+
 public class FunctionClassInstantiationException extends FunctionLoadException {
     public FunctionClassInstantiationException(String message, Throwable cause) {
         super(message, cause);

--- a/runtime/src/main/java/com/fnproject/fn/runtime/exception/InvalidEntryPointException.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/exception/InvalidEntryPointException.java
@@ -1,5 +1,7 @@
 package com.fnproject.fn.runtime.exception;
 
+import com.fnproject.fn.api.exception.FunctionLoadException;
+
 /**
  * The function entrypoint was malformed.
  */

--- a/runtime/src/main/java/com/fnproject/fn/runtime/exception/InvalidFunctionDefinitionException.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/exception/InvalidFunctionDefinitionException.java
@@ -1,5 +1,7 @@
 package com.fnproject.fn.runtime.exception;
 
+import com.fnproject.fn.api.exception.FunctionLoadException;
+
 /**
  * the function definition passed was invalid (e.g. class or method did not exist in jar, or method did not match required signature)
  */

--- a/testing/src/main/java/com/fnproject/fn/testing/FnTestingRule.java
+++ b/testing/src/main/java/com/fnproject/fn/testing/FnTestingRule.java
@@ -100,6 +100,7 @@ public final class FnTestingRule implements TestRule {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final List<String> sharedPrefixes = new ArrayList<>();
+    private int lastExitCode;
 
     {
         // Internal shared classes required to bridge completer into tests
@@ -261,7 +262,7 @@ public final class FnTestingRule implements TestRule {
                 oldSystemErr.println("         This may result in unexpected behaviour around function initialization and configuration.");
             }
             forked.setCompleterClient(completer);
-            forked.run(
+            lastExitCode = forked.run(
                mutableEnv,
                pendingInput,
                functionOut,
@@ -281,6 +282,16 @@ public final class FnTestingRule implements TestRule {
             System.setErr(oldSystemErr);
 
         }
+    }
+
+    /**
+     * Get the exit code from the most recent invocation
+     * 0 = success
+     * 1 = failed
+     * 2 = not run due to initialization error
+     */
+    public int getLastExitCode() {
+        return lastExitCode;
     }
 
     /**


### PR DESCRIPTION
If you specified a function which didn't exist, or tried to use default function selection without actually supplying a function that could be used then you would get a NullPointerException.

Until now.

Now you get a failure with a *sensible* error message