### PR TITLE
Use < and > inside of {@code} Javadoc section

### DIFF
--- a/api/src/main/java/com/fnproject/fn/api/TypeWrapper.java
+++ b/api/src/main/java/com/fnproject/fn/api/TypeWrapper.java
@@ -11,11 +11,11 @@ public interface TypeWrapper {
      *
      * For example, take the following classes:
      * <pre>{@code
-     * class GenericParent&lt;T&gt; {
+     * class GenericParent<T> {
      *   public void someMethod(T t) { // do something with t }
      * }
      *
-     * class ConcreteClass extends GenericParent&lt;String&gt; { }
+     * class ConcreteClass extends GenericParent<String> { }
      * }</pre>
      *
      * A {@link TypeWrapper} representing the first argument of {@code someMethod} would return {@code String.class}


### PR DESCRIPTION
While reading the Javadoc I realized that it shows `&lt;` and `&gt;` inside of Javadoc sample for `TypeWrapper` which I generated and viewed as:
```bash
fdk-java/api$ mvn clean javadoc:javadoc
fdk-java/api$ firefox target/site/apidocs/com/fnproject/fn/api/TypeWrapper.html
```
The sample for revision 7ac184b0e37b65ef28d4609e78ba4d6d611b0fd4 does not represent compilable Java code:
```java
 class GenericParent&lt;T&gt; {
   public void someMethod(T t) { // do something with t }
 }

 class ConcreteClass extends GenericParent&lt;String&gt; { }
```
With my change the sample looks as it should:
```java
 class GenericParent<T> {
   public void someMethod(T t) { // do something with t }
 }

 class ConcreteClass extends GenericParent<String> { }
```
Please consider accepting my documentation fix.