### PR TITLE
Updated dependency versions to reduce security problems

### DIFF
--- a/examples/async-thumbnails/pom.xml
+++ b/examples/async-thumbnails/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
-            <version>3.0.5</version>
+            <version>3.0.12</version>
         </dependency>
         <dependency>
             <groupId>com.fnproject.fn</groupId>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.7.1</version>
+            <version>2.18.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/async-thumbnails/src/test/java/com/fnproject/fn/examples/ThumbnailsFunctionTest.java
+++ b/examples/async-thumbnails/src/test/java/com/fnproject/fn/examples/ThumbnailsFunctionTest.java
@@ -42,10 +42,10 @@ public class ThumbnailsFunctionTest {
         testing.thenRun(ThumbnailsFunction.class, "handleRequest");
 
         // Check the final image uploads were performed
-        mockServer.verify(1, putRequestedFor(urlMatching("/alpha/.*\\.png")).withRequestBody(equalTo("testing")));
-        mockServer.verify(1, putRequestedFor(urlMatching("/alpha/.*\\.png")).withRequestBody(equalTo("128")));
-        mockServer.verify(1, putRequestedFor(urlMatching("/alpha/.*\\.png")).withRequestBody(equalTo("256")));
-        mockServer.verify(1, putRequestedFor(urlMatching("/alpha/.*\\.png")).withRequestBody(equalTo("512")));
+        mockServer.verify(putRequestedFor(urlMatching("/alpha/.*\\.png")).withRequestBody(containing("testing")));
+        mockServer.verify(putRequestedFor(urlMatching("/alpha/.*\\.png")).withRequestBody(containing("128")));
+        mockServer.verify(putRequestedFor(urlMatching("/alpha/.*\\.png")).withRequestBody(containing("256")));
+        mockServer.verify(putRequestedFor(urlMatching("/alpha/.*\\.png")).withRequestBody(containing("512")));
         mockServer.verify(4, putRequestedFor(urlMatching(".*")));
     }
 

--- a/examples/regex-query/pom.xml
+++ b/examples/regex-query/pom.xml
@@ -7,7 +7,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <fnproject.version>1.0.0-SNAPSHOT</fnproject.version>
-        <jackson.version>2.8.9</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
     </properties>
 
     <groupId>com.fnproject.fn.examples</groupId>

--- a/fn-spring-cloud-function/pom.xml
+++ b/fn-spring-cloud-function/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.cloud.function.version>1.0.0.M1</spring.cloud.function.version>
+        <spring.cloud.function.version>1.0.0.M6</spring.cloud.function.version>
     </properties>
 
     <dependencies>
@@ -67,6 +67,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.1.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/SpringCloudFunctionInvoker.java
+++ b/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/SpringCloudFunctionInvoker.java
@@ -145,7 +145,7 @@ public class SpringCloudFunctionInvoker implements FunctionInvoker, Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         applicationContext.close();
     }
 }

--- a/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/SpringCloudFunctionLoader.java
+++ b/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/SpringCloudFunctionLoader.java
@@ -6,8 +6,8 @@ import com.fnproject.springframework.function.functions.SpringCloudFunction;
 import com.fnproject.springframework.function.functions.SpringCloudMethod;
 import com.fnproject.springframework.function.functions.SpringCloudSupplier;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.function.context.FunctionInspector;
-import org.springframework.cloud.function.core.FunctionCatalog;
+import org.springframework.cloud.function.context.FunctionCatalog;
+import org.springframework.cloud.function.context.catalog.FunctionInspector;
 import reactor.core.publisher.Flux;
 
 import java.util.function.Consumer;
@@ -67,24 +67,24 @@ public class SpringCloudFunctionLoader {
     private void loadSpringCloudFunctionFromEnvVars() {
         String functionName = System.getenv(ENV_VAR_FUNCTION_NAME);
         if (functionName != null) {
-            function = this.catalog.lookupFunction(functionName);
+            function = this.catalog.lookup(Function.class, functionName);
         }
 
         String consumerName = System.getenv(ENV_VAR_CONSUMER_NAME);
         if (consumerName != null) {
-            consumer = this.catalog.lookupConsumer(consumerName);
+            consumer = this.catalog.lookup(Consumer.class, consumerName);
         }
 
         String supplierName = System.getenv(ENV_VAR_SUPPLIER_NAME);
         if (supplierName != null) {
-            supplier = this.catalog.lookupSupplier(supplierName);
+            supplier = this.catalog.lookup(Supplier.class, supplierName);
         }
     }
 
     private void loadSpringCloudFunctionFromDefaults() {
-        function = this.catalog.lookupFunction(DEFAULT_FUNCTION_BEAN);
-        consumer = this.catalog.lookupConsumer(DEFAULT_CONSUMER_BEAN);
-        supplier = this.catalog.lookupSupplier(DEFAULT_SUPPLIER_BEAN);
+        function = this.catalog.lookup(Function.class, DEFAULT_FUNCTION_BEAN);
+        consumer = this.catalog.lookup(Consumer.class, DEFAULT_CONSUMER_BEAN);
+        supplier = this.catalog.lookup(Supplier.class, DEFAULT_SUPPLIER_BEAN);
     }
 
 

--- a/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/functions/SpringCloudConsumer.java
+++ b/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/functions/SpringCloudConsumer.java
@@ -2,7 +2,7 @@ package com.fnproject.springframework.function.functions;
 
 import com.fnproject.fn.api.TypeWrapper;
 import com.fnproject.springframework.function.SimpleTypeWrapper;
-import org.springframework.cloud.function.context.FunctionInspector;
+import org.springframework.cloud.function.context.catalog.FunctionInspector;
 import reactor.core.publisher.Flux;
 
 import java.util.function.Consumer;

--- a/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/functions/SpringCloudFunction.java
+++ b/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/functions/SpringCloudFunction.java
@@ -1,6 +1,6 @@
 package com.fnproject.springframework.function.functions;
 
-import org.springframework.cloud.function.context.FunctionInspector;
+import org.springframework.cloud.function.context.catalog.FunctionInspector;
 import reactor.core.publisher.Flux;
 
 import java.util.function.Consumer;

--- a/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/functions/SpringCloudMethod.java
+++ b/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/functions/SpringCloudMethod.java
@@ -3,7 +3,7 @@ package com.fnproject.springframework.function.functions;
 import com.fnproject.fn.api.MethodWrapper;
 import com.fnproject.fn.api.TypeWrapper;
 import com.fnproject.springframework.function.SimpleTypeWrapper;
-import org.springframework.cloud.function.context.FunctionInspector;
+import org.springframework.cloud.function.context.catalog.FunctionInspector;
 import reactor.core.publisher.Flux;
 
 import java.lang.reflect.Method;

--- a/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/functions/SpringCloudSupplier.java
+++ b/fn-spring-cloud-function/src/main/java/com/fnproject/springframework/function/functions/SpringCloudSupplier.java
@@ -2,10 +2,9 @@ package com.fnproject.springframework.function.functions;
 
 import com.fnproject.fn.api.TypeWrapper;
 import com.fnproject.springframework.function.SimpleTypeWrapper;
-import org.springframework.cloud.function.context.FunctionInspector;
+import org.springframework.cloud.function.context.catalog.FunctionInspector;
 import reactor.core.publisher.Flux;
 
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**

--- a/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/SimpleFunctionInspector.java
+++ b/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/SimpleFunctionInspector.java
@@ -1,13 +1,19 @@
 package com.fnproject.springframework.function;
 
 import net.jodah.typetools.TypeResolver;
-import org.springframework.cloud.function.context.FunctionInspector;
+import org.springframework.cloud.function.context.FunctionRegistration;
+import org.springframework.cloud.function.context.catalog.FunctionInspector;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class SimpleFunctionInspector implements FunctionInspector {
+    @Override
+    public FunctionRegistration<?> getRegistration(Object function) {
+        return null;
+    }
+
     @Override
     public boolean isMessage(Object function) {
         throw new IllegalStateException("Not implemented");
@@ -50,11 +56,6 @@ public class SimpleFunctionInspector implements FunctionInspector {
 
     @Override
     public Class<?> getOutputWrapper(Object function) {
-        throw new IllegalStateException("Not implemented");
-    }
-
-    @Override
-    public Object convert(Object function, String value) {
         throw new IllegalStateException("Not implemented");
     }
 

--- a/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/SpringCloudFunctionLoaderTest.java
+++ b/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/SpringCloudFunctionLoaderTest.java
@@ -8,7 +8,7 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.cloud.function.core.FunctionCatalog;
+import org.springframework.cloud.function.context.catalog.InMemoryFunctionCatalog;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -24,8 +24,9 @@ public class SpringCloudFunctionLoaderTest {
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     private SpringCloudFunctionLoader loader;
+
     @Mock
-    private FunctionCatalog catalog;
+    private InMemoryFunctionCatalog catalog;
 
     @Before
     public void setUp() {
@@ -34,9 +35,7 @@ public class SpringCloudFunctionLoaderTest {
     }
 
     private void setUpCatalogToReturnNullForLookupByDefault() {
-        when(catalog.lookupFunction(any())).thenReturn(null);
-        when(catalog.lookupConsumer(any())).thenReturn(null);
-        when(catalog.lookupSupplier(any())).thenReturn(null);
+        when(catalog.lookup(any(), any())).thenReturn(null);
     }
 
     @Test
@@ -49,7 +48,8 @@ public class SpringCloudFunctionLoaderTest {
 
     @Test
     public void shouldLoadConsumerBeanCalledConsumerIfFunctionNotAvailable() {
-        Consumer<Object> consumer = (x) -> {};
+        Consumer<Object> consumer = (x) -> {
+        };
         stubCatalogToReturnConsumer(consumer);
 
         assertThat(getDiscoveredFunction().getTargetClass()).isEqualTo(consumer.getClass());
@@ -80,7 +80,8 @@ public class SpringCloudFunctionLoaderTest {
     @Test
     public void shouldLoadUserSpecifiedConsumerInEnvVarOverDefaultFunction() {
         String beanName = "myConsumer";
-        Consumer<Object> consumer = (x) -> {};
+        Consumer<Object> consumer = (x) -> {
+        };
         Function<Object, Object> function = (x) -> x;
 
         setConsumerEnvVar(beanName);
@@ -104,15 +105,15 @@ public class SpringCloudFunctionLoaderTest {
     }
 
     private void stubCatalogToReturnFunction(String beanName, Function<Object, Object> function) {
-        when(catalog.lookupFunction(beanName)).thenReturn(function);
+        when(catalog.lookup(Function.class, beanName)).thenReturn(function);
     }
 
     private void stubCatalogToReturnConsumer(String beanName, Consumer<Object> consumer) {
-        when(catalog.lookupConsumer(beanName)).thenReturn(consumer);
+        when(catalog.lookup(Consumer.class, beanName)).thenReturn(consumer);
     }
 
     private void stubCatalogToReturnSupplier(String beanName, Supplier<Object> supplier) {
-        when(catalog.lookupSupplier(beanName)).thenReturn(supplier);
+        when(catalog.lookup(Supplier.class, beanName)).thenReturn(supplier);
     }
 
     private void stubCatalogToReturnSupplier(Supplier<Object> supplier) {

--- a/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/testfns/EmptyFunctionConfig.java
+++ b/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/testfns/EmptyFunctionConfig.java
@@ -3,14 +3,9 @@ package com.fnproject.springframework.function.testfns;
 import com.fnproject.fn.api.FnConfiguration;
 import com.fnproject.fn.api.RuntimeContext;
 import com.fnproject.springframework.function.SpringCloudFunctionInvoker;
-import org.springframework.cloud.function.context.ContextFunctionCatalogAutoConfiguration;
-import org.springframework.context.annotation.Bean;
+import org.springframework.cloud.function.context.config.ContextFunctionCatalogAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 @Configuration
 @Import(ContextFunctionCatalogAutoConfiguration.class)

--- a/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/testfns/FunctionConfig.java
+++ b/fn-spring-cloud-function/src/test/java/com/fnproject/springframework/function/testfns/FunctionConfig.java
@@ -3,7 +3,7 @@ package com.fnproject.springframework.function.testfns;
 import com.fnproject.fn.api.FnConfiguration;
 import com.fnproject.fn.api.RuntimeContext;
 import com.fnproject.springframework.function.SpringCloudFunctionInvoker;
-import org.springframework.cloud.function.context.ContextFunctionCatalogAutoConfiguration;
+import org.springframework.cloud.function.context.config.ContextFunctionCatalogAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -15,11 +15,14 @@ import java.util.function.Supplier;
 @Configuration
 @Import(ContextFunctionCatalogAutoConfiguration.class)
 public class FunctionConfig {
+
     @FnConfiguration
     public static void configure(RuntimeContext ctx) {
         ctx.setInvoker(new SpringCloudFunctionInvoker(FunctionConfig.class));
     }
-    public void handleRequest() { }
+
+    public void handleRequest() {
+    }
 
     @Bean
     public Supplier<String> supplier() {
@@ -28,6 +31,7 @@ public class FunctionConfig {
 
     @Bean
     public Consumer<String> consumer() {
+        System.out.println("LOADED");
         return System.out::println;
     }
 
@@ -35,13 +39,16 @@ public class FunctionConfig {
     public Function<String, String> function() {
         return String::toLowerCase;
     }
+
     @Bean
     public Function<String, String> upperCaseFunction() {
         return String::toUpperCase;
     }
 
     @Bean
-    public String notAFunction() { return "NotAFunction"; }
+    public String notAFunction() {
+        return "NotAFunction";
+    }
 
     // Empty entrypoint that isn't used but necessary for the EntryPoint. Our invoker ignores this and loads our own
     // function to invoke

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <jacoco.version>0.7.9</jacoco.version>
         <slf4j.version>1.7.25</slf4j.version>
         <commons-io.version>2.5</commons-io.version>
-        <jackson.version>2.8.7</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
         <mockito.version>2.8.47</mockito.version>
         <assertj-core.version>3.6.2</assertj-core.version>
         <httpcore.version>4.4.6</httpcore.version>


### PR DESCRIPTION
Updated dependency versions to reduce security problems

Using snyk.io tools we found several dependencies had security vulnerabilities
and could be updated. This does not remove all of them, but the remaining CVEs
are in transitive dependencies brought in by 3rd party code.

CVEs remain in:

async-thumbnails example (low priority to fix) through
  - minio
  - wiremock

fn-spring-cloud-function through
  - spring-cloud-function-context

Additional changes were needed to adjust for API changes in updated dependencies:

async-thumbnails example:
  - new minio client uses chunked file uploads so assertions needed changing

fn-spring-cloud-function:
  - Several breaking API changes, and it seems now that Consumer behaviour is broken.

