### PR TITLE
make FnFeature multi-valued remove use of getAnnotationsByType

### DIFF
--- a/api/src/main/api/snapshot.sigfile
+++ b/api/src/main/api/snapshot.sigfile
@@ -7,10 +7,17 @@ CLSS public abstract interface !annotation com.fnproject.fn.api.FnConfiguration
 intf java.lang.annotation.Annotation
 
 CLSS public abstract interface !annotation com.fnproject.fn.api.FnFeature
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class com.fnproject.fn.api.FnFeatures)
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.Class<? extends com.fnproject.fn.api.RuntimeFeature> value()
+
+CLSS public abstract interface !annotation com.fnproject.fn.api.FnFeatures
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract com.fnproject.fn.api.FnFeature[] value()
 
 CLSS public abstract interface com.fnproject.fn.api.FunctionInvoker
 innr public final static !enum Phase
@@ -259,6 +266,13 @@ CLSS public abstract interface !annotation java.lang.annotation.Documented
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
 intf java.lang.annotation.Annotation
+
+CLSS public abstract interface !annotation java.lang.annotation.Repeatable
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.Class<? extends java.lang.annotation.Annotation> value()
 
 CLSS public abstract interface !annotation java.lang.annotation.Retention
  anno 0 java.lang.annotation.Documented()

--- a/api/src/main/java/com/fnproject/fn/api/FnFeatures.java
+++ b/api/src/main/java/com/fnproject/fn/api/FnFeatures.java
@@ -1,6 +1,9 @@
 package com.fnproject.fn.api;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotation to be used in user function classes to enable runtime-wide feature.
@@ -9,11 +12,6 @@ import java.lang.annotation.*;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@Repeatable(FnFeatures.class)
-public @interface FnFeature {
-    /**
-     * The feature class to load this must have a zero-arg public constructor
-     * @return feature class
-     */
-    Class<? extends  RuntimeFeature> value();
+public @interface FnFeatures {
+   FnFeature[] value();
 }

--- a/testing-junit4/src/main/java/com/fnproject/fn/testing/FnTestingRule.java
+++ b/testing-junit4/src/main/java/com/fnproject/fn/testing/FnTestingRule.java
@@ -1,9 +1,7 @@
 package com.fnproject.fn.testing;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fnproject.fn.api.Headers;
-import com.fnproject.fn.api.InputEvent;
-import com.fnproject.fn.api.OutputEvent;
+import com.fnproject.fn.api.*;
 import com.fnproject.fn.runtime.EventCodec;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.junit.Rule;
@@ -77,6 +75,7 @@ public final class FnTestingRule implements TestRule {
         addSharedClass(TestCodec.class);
         addSharedClass(EventCodec.class);
         addSharedClass(EventCodec.Handler.class);
+
 
 
     }


### PR DESCRIPTION
Hey @tzezula  - i've made the FnFeature multi @repeatable and also dropped back to more pedestrian annotation methods - are these supported in substrate? 