### PR TITLE
Bump Jackson version

### DIFF
--- a/examples/async-thumbnails/pom.xml
+++ b/examples/async-thumbnails/pom.xml
@@ -10,7 +10,7 @@
 
         <fdk.version>1.0.0-SNAPSHOT</fdk.version>
         <mockito.version>2.8.47</mockito.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
     </properties>
 
     <groupId>com.fnproject.fn.examples</groupId>

--- a/examples/regex-query/pom.xml
+++ b/examples/regex-query/pom.xml
@@ -9,7 +9,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <fdk.version>1.0.0-SNAPSHOT</fdk.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
     </properties>
 
     <groupId>com.fnproject.fn.examples</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <assertj-core.version>3.6.2</assertj-core.version>
         <commons-io.version>2.5</commons-io.version>
-        <jackson.version>2.9.6</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <junit.version>4.12</junit.version>
         <surefire.version>2.22.1</surefire.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <assertj-core.version>3.10.0</assertj-core.version>
         <commons-io.version>2.6</commons-io.version>
         <httpcore.version>4.4.10</httpcore.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <jacoco.version>0.8.1</jacoco.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
Bumps Jackson version to 2.9.8 to address CVE-2018-19360, CVE-2018-19361 and CVE-2018-19362