### PR TITLE
Removed useless entries from the SVM func.yaml

### DIFF
--- a/images/init-native/func.init.yaml
+++ b/images/init-native/func.init.yaml
@@ -1,2 +1,0 @@
-runtime: docker
-format: http-stream


### PR DESCRIPTION
Note that an empty func.init.yaml should be present, if not CLI will complain that "init-image did not produce a valid func.init.yaml"