### PR TITLE
Fix path of java binary in Dockerfile

### DIFF
--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:8-slim
+FROM openjdk:8-jre-slim
 COPY target/runtime-*.jar target/dependency/*.jar /function/runtime/
 COPY src/main/c/libfnunixsocket.so /function/runtime/lib/
 
-RUN ["/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-Xshare:dump"]
+RUN ["java", "-Xshare:dump"]
 
 RUN addgroup --system --gid 1000 fn && adduser --uid 1000 --gid 1000 fn
 
@@ -18,4 +18,4 @@ RUN addgroup --system --gid 1000 fn && adduser --uid 1000 --gid 1000 fn
 #
 # The max memory value obtained with these args seem to be okay for most memory limits. The exception is when the
 # memory limit is set to 128MiB, in which case maxMemory returns roughly half.
-ENTRYPOINT [ "/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-XX:-UsePerfData", "-XX:MaxRAMFraction=2", "-XX:+UseSerialGC", "-Xshare:on", "-Djava.library.path=/function/runtime/lib", "-cp", "/function/app/*:/function/runtime/*", "com.fnproject.fn.runtime.EntryPoint" ]
+ENTRYPOINT [ "java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-XX:-UsePerfData", "-XX:MaxRAMFraction=2", "-XX:+UseSerialGC", "-Xshare:on", "-Djava.library.path=/function/runtime/lib", "-cp", "/function/app/*:/function/runtime/*", "com.fnproject.fn.runtime.EntryPoint" ]


### PR DESCRIPTION
Java 8 Dockerfile specified absolute path to `java` binary which has seemingly changed in latest versions of `openjdk:8-slim` image (possibly due to https://github.com/docker-library/openjdk/commit/3eb0351b208d739fac35345c85e3c6237c2114ec#diff-e29295585240d6f18a944f2a83a10505) and broke the build. This changes it to simply `java`.