### PR TITLE
Update all names to Function Development Kit for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![CircleCI](https://circleci.com/gh/fnproject/fdk-java.svg?style=svg&circle-token=348bec5610c34421f6c436ab8f6a18e153cb1c01)](https://circleci.com/gh/fnproject/fdk-java)
 
-# Function Development Kit for Java (FDK Java)
+# Function Development Kit for Java (FDK for Java)
 
-The Function Development Kit for Java (FDK Java) makes it easy to build and deploy Java functions to Fn with full support for Java 11+ as the default out of the box.
+The Function Development Kit for Java makes it easy to build and deploy Java functions to Fn with full support for Java 11+ as the default out of the box.
 
-Some of the FDK Java features include:
+Some of the FDK for Java features include:
 
 - Parsing input and writing output
 - Flexible data binding to Java objects
@@ -17,7 +17,7 @@ New to Fn Project? If you want to learn more about using the Fn Project to power
 
 ## Using the Function Development Kit for Java
 
-For detailed instructions on using FDK Java to build and deploy Java functions to Fn, please see the official FDK Java developer guide in our docs repo here: https://github.com/fnproject/docs/blob/master/fdks/fdk-java/README.md.
+For detailed instructions on using the FDK to build and deploy Java functions to Fn, please see the official FDK developer guide in our docs repo here: https://github.com/fnproject/docs/blob/master/fdks/fdk-java/README.md.
 
 ## Contributing to the Function Development Kit for Java
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![CircleCI](https://circleci.com/gh/fnproject/fdk-java.svg?style=svg&circle-token=348bec5610c34421f6c436ab8f6a18e153cb1c01)](https://circleci.com/gh/fnproject/fdk-java)
 
-# Java Function Development Kit (FDK)
+# Function Development Kit for Java (FDK-Java)
 
-The Java Function Development Kit (FDK) makes it easy to build and deploy Java functions to Fn with full support for Java 11+ as the default out of the box.
+The Function Development Kit for Java (FDK-Java) makes it easy to build and deploy Java functions to Fn with full support for Java 11+ as the default out of the box.
 
-Some of the Java FDK's features include:
+Some of the FDK-Java features include:
 
 - Parsing input and writing output
 - Flexible data binding to Java objects
@@ -15,14 +15,10 @@ Some of the Java FDK's features include:
 
 New to Fn Project? If you want to learn more about using the Fn Project to power your next project, start with the [official documentation](https://github.com/fnproject/docs).
 
-## Using the Java FDK
+## Using the Function Development Kit for Java
 
-For detailed instructions on using the Java FDK to build and deploy Java functions to Fn, please see the official Java FDK developer guide in our docs repo here: https://github.com/fnproject/docs/blob/master/fdks/fdk-java/README.md.
+For detailed instructions on using FDK-Java to build and deploy Java functions to Fn, please see the official FDK-Java developer guide in our docs repo here: https://github.com/fnproject/docs/blob/master/fdks/fdk-java/README.md.
 
-## Contributing to the Java FDK
+## Contributing to the Function Development Kit for Java
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![CircleCI](https://circleci.com/gh/fnproject/fdk-java.svg?style=svg&circle-token=348bec5610c34421f6c436ab8f6a18e153cb1c01)](https://circleci.com/gh/fnproject/fdk-java)
 
-# Function Development Kit for Java (FDK-Java)
+# Function Development Kit for Java (FDK Java)
 
-The Function Development Kit for Java (FDK-Java) makes it easy to build and deploy Java functions to Fn with full support for Java 11+ as the default out of the box.
+The Function Development Kit for Java (FDK Java) makes it easy to build and deploy Java functions to Fn with full support for Java 11+ as the default out of the box.
 
-Some of the FDK-Java features include:
+Some of the FDK Java features include:
 
 - Parsing input and writing output
 - Flexible data binding to Java objects
@@ -17,7 +17,7 @@ New to Fn Project? If you want to learn more about using the Fn Project to power
 
 ## Using the Function Development Kit for Java
 
-For detailed instructions on using FDK-Java to build and deploy Java functions to Fn, please see the official FDK-Java developer guide in our docs repo here: https://github.com/fnproject/docs/blob/master/fdks/fdk-java/README.md.
+For detailed instructions on using FDK Java to build and deploy Java functions to Fn, please see the official FDK Java developer guide in our docs repo here: https://github.com/fnproject/docs/blob/master/fdks/fdk-java/README.md.
 
 ## Contributing to the Function Development Kit for Java
 


### PR DESCRIPTION
 Per Shaun, per Legal and for consistency, all FDKs should be titled Function Development Kit for <language>. Thus we are updating to **Function Development Kit for Java** where the title occurs.