### PR TITLE
Add Fn-Fdk-Version to java fdk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,22 +26,22 @@ mvn  -B  deploy -DaltDeploymentRepository=localStagingDir::default::file://${REP
 
 (
   cd images/build
-  ./docker-build.sh -t fnproject/fn-java-fdk-build:${BUILD_VERSION} .
+  ./docker-build.sh --no-cache -t fnproject/fn-java-fdk-build:${BUILD_VERSION} .
 )
 
 (
   cd images/build
-  ./docker-build.sh -f Dockerfile-jdk11 -t fnproject/fn-java-fdk-build:jdk11-${BUILD_VERSION} .
+  ./docker-build.sh --no-cache -f Dockerfile-jdk11 -t fnproject/fn-java-fdk-build:jdk11-${BUILD_VERSION} .
 )
 
 (
    cd runtime
-   docker build -t fnproject/fn-java-fdk:${BUILD_VERSION}  -f ../images/runtime/Dockerfile .
+   docker build --no-cache -t fnproject/fn-java-fdk:${BUILD_VERSION}  -f ../images/runtime/Dockerfile .
 )
 
 (
    cd runtime
-   docker build -f ../images/runtime/Dockerfile-jre11 -t fnproject/fn-java-fdk:jre11-${BUILD_VERSION} .
+   docker build --no-cache -f ../images/runtime/Dockerfile-jre11 -t fnproject/fn-java-fdk:jre11-${BUILD_VERSION} .
 )
 
 (

--- a/integration-tests/src/test/java/com/fnproject/fn/integrationtest/FunctionsTest.java
+++ b/integration-tests/src/test/java/com/fnproject/fn/integrationtest/FunctionsTest.java
@@ -1,18 +1,18 @@
 package com.fnproject.fn.integrationtest;
 
+import java.net.HttpURLConnection;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fnproject.fn.integrationtest.IntegrationTestRule.CmdResult;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Logger;
-import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,8 +45,8 @@ public class FunctionsTest {
 
     @Test()
     public void checkBoilerPlate() throws Exception {
-        for (String runtime : new String[]{"java8", "java11"}) {
-	    IntegrationTestRule.TestContext tc = testRule.newTest();
+        for (String runtime : new String[] {"java8", "java11"}) {
+            IntegrationTestRule.TestContext tc = testRule.newTest();
             String fnName = "bp" + runtime;
             tc.runFn("init", "--runtime", runtime, "--name", fnName);
             tc.rewritePOM();
@@ -83,7 +83,7 @@ public class FunctionsTest {
         HttpURLConnection con = (HttpURLConnection) invokeURL.openConnection();
 
         con.setRequestMethod("POST");
-        con.addRequestProperty("Foo","bar");
+        con.addRequestProperty("Foo", "bar");
 
 
         assertThat(con.getResponseCode()).isEqualTo(202);
@@ -91,6 +91,33 @@ public class FunctionsTest {
         assertThat(con.getHeaderField("GotURL")).isEqualTo(url);
         assertThat(con.getHeaderField("GotHeader")).isEqualTo("bar");
         assertThat(con.getHeaderField("MyHTTPHeader")).isEqualTo("foo");
+
+    }
+
+    @Test
+    public void shouldGetFDKVersion() throws Exception {
+        IntegrationTestRule.TestContext tc = testRule.newTest();
+        tc.withDirFrom("funcs/simpleFunc").rewritePOM();
+
+        tc.runFn("--verbose", "deploy", "--create-app", "--app", tc.appName(), "--local");
+        tc.runFn("config", "app", tc.appName(), "GREETING", "Salutations");
+
+        CmdResult r1 = tc.runFn("inspect", "function", tc.appName(), "simplefunc", "--endpoint");
+
+        String url = r1.getStdout().trim();
+
+        HttpURLConnection conn = (HttpURLConnection) (new URL(url).openConnection(Proxy.NO_PROXY));
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json; utf-8");
+        conn.setDoInput(true);
+        conn.setDoOutput(true);
+        conn.getOutputStream().write(new byte[0]);
+        Map<String, List<String>> headers = conn.getHeaderFields();
+
+        assertThat(headers).hasEntrySatisfying("Fn-Fdk-Version", (val) -> {
+            assertThat(val).isNotEmpty();
+            assertThat(val.get(0)).matches("fdk-java/\\d+\\.\\d+\\.\\d+(-SNAPSHOT)? \\(jvm=.*, jvmv=.*\\)");
+        });
 
     }
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -75,6 +75,13 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/java-filtered</directory>
+                <targetPath>${build.directory}/version-sources</targetPath>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -89,6 +96,23 @@
                             <outputDirectory>${project.build.directory}/dependency</outputDirectory>
                             <includeScope>runtime</includeScope>
                             <prependGroupId>true</prependGroupId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/version-sources</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/runtime/src/main/java-filtered/com/fnproject/fn/runtime/Version.java
+++ b/runtime/src/main/java-filtered/com/fnproject/fn/runtime/Version.java
@@ -1,0 +1,14 @@
+package com.fnproject.fn.runtime;
+
+/**
+ * This uses maven-resource filtering rather than conventional manifest versioning as it's more robust against resource changes than using standard META-INF/MANIFEST.MF
+ * versioning. For native image functions this negates the need for extra configuration to include manifest resources.
+ *
+ * Created on 18/02/2020.
+ * <p>
+ *
+ * (c) 2020 Oracle Corporation
+ */
+public class Version {
+    public static final String FDK_VERSION="${project.version}";
+}


### PR DESCRIPTION
This adds Fn-Fdk-Version to each response from the FDK - this allows services to track which version of the FDK is in use at a given time. 

In addition to the specific FDK version  java has several variants (java version, graal vs openJDK) 

Per discusion with @roroco  - I've added a comment to the version header  that encodes these 

This uses maven placeholders to rewrite the version number into a string literal - this is done to reduce startup time (by avoiding having to load resources at startup) and remove the need for substrate functions to explicitly include resources in their build configuration. 


the new header looks like this for graal: 

```
 Fn-Fdk-Version: fdk-java/1.0.0-SNAPSHOT (jvm=Substrate VM, jvmv=1.8.0_222)
```
and for openjdk: 
```
 Fn-Fdk-Version: fdk-java/1.0.0-SNAPSHOT (jvm=OpenJDK 64-Bit Server VM, jvmv=11.0.6)

```