### PR TITLE
Refresh the Java FDK dependencies to more recent versions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,9 @@ We welcome all contributions!
    * Don't make breaking changes to the public APIs.
    * Write tests - especially for public APIs.
    * Make sure that changes to `api` are backwards compatible with `runtime` and vice-versa.
+   
+## Note for mac users
+   #### If you run into build failures, try the steps below:
+   * Install `cmake`, if you don't have it already by running `brew install cmake`
+   * Go to `fdk-java/runtime/src/main/c` folder and run `./buildit.sh`
   

--- a/examples/async-thumbnails/pom.xml
+++ b/examples/async-thumbnails/pom.xml
@@ -9,8 +9,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <fdk.version>1.0.0-SNAPSHOT</fdk.version>
-        <mockito.version>2.8.47</mockito.version>
-        <jackson.version>2.10.3</jackson.version>
+        <mockito.version>3.3.3</mockito.version>
+        <jackson.version>2.11.0</jackson.version>
     </properties>
 
     <groupId>com.fnproject.fn.examples</groupId>

--- a/examples/regex-query/pom.xml
+++ b/examples/regex-query/pom.xml
@@ -9,7 +9,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <fdk.version>1.0.0-SNAPSHOT</fdk.version>
-        <jackson.version>2.10.3</jackson.version>
+        <jackson.version>2.11.0</jackson.version>
     </properties>
 
     <groupId>com.fnproject.fn.examples</groupId>

--- a/images/init-native/pom.xml
+++ b/images/init-native/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <fdk.version>1.0.107</fdk.version>
+        <fdk.version>1.0.0-SNAPSHOT</fdk.version>
     </properties>
     <groupId>com.example.fn</groupId>
     <artifactId>hello</artifactId>

--- a/integration-tests/funcs/flowAllFeatures/pom.xml
+++ b/integration-tests/funcs/flowAllFeatures/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.6</version>
         </dependency>
     </dependencies>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -9,9 +9,9 @@
     <artifactId>integration-tests</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <properties>
-        <assertj-core.version>3.6.2</assertj-core.version>
-        <commons-io.version>2.5</commons-io.version>
-        <jackson.version>2.10.3</jackson.version>
+        <assertj-core.version>3.16.1</assertj-core.version>
+        <commons-io.version>2.6</commons-io.version>
+        <jackson.version>2.11.0</jackson.version>
         <junit.version>4.12</junit.version>
         <surefire.version>2.22.1</surefire.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,14 +27,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <assertj-core.version>3.10.0</assertj-core.version>
+        <assertj-core.version>3.16.1</assertj-core.version>
         <commons-io.version>2.6</commons-io.version>
-        <httpcore.version>4.4.10</httpcore.version>
-        <jackson.version>2.10.3</jackson.version>
+        <httpcore.version>4.4.13</httpcore.version>
+        <jackson.version>2.11.0</jackson.version>
         <jacoco.version>0.8.1</jacoco.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <junit.version>4.12</junit.version>
-        <mockito.version>2.21.0</mockito.version>
+        <mockito.version>3.3.3</mockito.version>
         <pitest.version>1.4.0</pitest.version>
         <slf4j.version>1.7.25</slf4j.version>
         <surefire.version>2.22.1</surefire.version>
@@ -95,7 +95,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.6</version>
+                <version>4.5.12</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>net.jodah</groupId>
                 <artifactId>typetools</artifactId>
-                <version>0.5.0</version>
+                <version>0.6.2</version>
             </dependency>
 
 


### PR DESCRIPTION
Version bumped multiple dependencies to more recent versions:
```
httpcore 4.4.10 -> 4.4.13
jackson-databind  2.10.3 -> 2.11.0
typetools 0.5.0 -> 0.6.2
httpclient 4.5.6 -> 4.5.12
mockito-core 2.21.0 -> 3.3.3
assertj-core 3.10.0 -> 3.16.1
```

Also added setup instructions for Mac users to `CONTRIBUTING.md`.