### PR TITLE
Add resources to classpath

### DIFF
--- a/images/runtime/Dockerfile
+++ b/images/runtime/Dockerfile
@@ -34,4 +34,4 @@ RUN addgroup --system --gid 1000 fn && adduser --uid 1000 --gid 1000 fn
 #
 # The max memory value obtained with these args seem to be okay for most memory limits. The exception is when the
 # memory limit is set to 128MiB, in which case maxMemory returns roughly half.
-ENTRYPOINT [ "java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-XX:-UsePerfData", "-XX:MaxRAMFraction=2", "-XX:+UseSerialGC", "-Xshare:on", "-Djava.library.path=/function/runtime/lib", "-cp", "/function/app/*:/function/runtime/*", "com.fnproject.fn.runtime.EntryPoint" ]
+ENTRYPOINT [ "java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-XX:-UsePerfData", "-XX:MaxRAMFraction=2", "-XX:+UseSerialGC", "-Xshare:on", "-Djava.library.path=/function/runtime/lib", "-cp", "/function/app/*:/function/runtime/*:/function/app:/function/app/resources", "com.fnproject.fn.runtime.EntryPoint" ]

--- a/images/runtime/Dockerfile-jre11
+++ b/images/runtime/Dockerfile-jre11
@@ -32,5 +32,5 @@ RUN addgroup --system --gid 1000 fn && adduser --uid 1000 --gid 1000 fn
 ENTRYPOINT [ "/usr/local/openjdk-11/bin/java", "-XX:-UsePerfData", "-XX:+UseSerialGC", "-Xshare:on", \
      "-Djava.awt.headless=true" , \
      "-Djava.library.path=/function/runtime/lib", \
-     "-cp", "/function/app/*:/function/runtime/*", \
+     "-cp", "/function/app/*:/function/runtime/*:/function/app:/function/app/resources", \
      "com.fnproject.fn.runtime.EntryPoint" ]


### PR DESCRIPTION
This PR addresses issues with loading of resources into the classpath. Previously only the wildcards were used so only jar or JAR was loaded and all other resources like logging properties and other configuration yaml/json/.. files were omitted. By appending `/function/app` to classpath all resources in this directory will be loaded. 