### PR TITLE
Logging is not always emitted when the function fails during startup

### DIFF
--- a/integration-tests/funcs/flowAllFeatures/pom.xml
+++ b/integration-tests/funcs/flowAllFeatures/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <fdk.version>1.0.0-SNAPSHOT</fdk.version>
+        <junit.version>4.13.1</junit.version>
     </properties>
     <groupId>com.fnproject.fn</groupId>
     <artifactId>integration-test-4</artifactId>
@@ -61,7 +62,7 @@
 		<dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/runtime/src/main/java/com/fnproject/fn/runtime/MethodFunctionInvoker.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/MethodFunctionInvoker.java
@@ -17,13 +17,18 @@
 package com.fnproject.fn.runtime;
 
 
-import com.fnproject.fn.api.*;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+
+import com.fnproject.fn.api.FunctionInvoker;
+import com.fnproject.fn.api.InputEvent;
+import com.fnproject.fn.api.InvocationContext;
+import com.fnproject.fn.api.MethodWrapper;
+import com.fnproject.fn.api.OutputEvent;
+import com.fnproject.fn.api.RuntimeContext;
 import com.fnproject.fn.api.exception.FunctionInputHandlingException;
 import com.fnproject.fn.api.exception.FunctionOutputHandlingException;
 import com.fnproject.fn.runtime.exception.InternalFunctionInvocationException;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.Optional;
 
 /**
  * Method function invoker
@@ -32,25 +37,6 @@ import java.util.Optional;
  * This handles the binding and invocation of function calls via java methods.
  */
 public class MethodFunctionInvoker implements FunctionInvoker {
-
-    /*
-    * If enabled, print the logging framing content
-    */
-    public void logFramer(FunctionRuntimeContext rctx, InputEvent evt) {
-        String framer = rctx.getConfigurationByKey("FN_LOGFRAME_NAME").orElse("");
-
-        if (framer != "") {
-            String valueSrc = rctx.getConfigurationByKey("FN_LOGFRAME_HDR").orElse("");
-
-            if (valueSrc != "") {
-                String id = evt.getHeaders().get(valueSrc).orElse("");
-                if (id != "") {
-                    System.out.println("\n" + framer + "=" + id + "\n");
-                    System.err.println("\n" + framer + "=" + id + "\n");
-                }
-            }
-        }
-    }
 
 
     /**
@@ -69,7 +55,6 @@ public class MethodFunctionInvoker implements FunctionInvoker {
 
         Object rawResult;
 
-        logFramer(runtimeContext, evt);
 
         try {
             rawResult = method.getTargetMethod().invoke(ctx.getRuntimeContext().getInvokeInstance().orElse(null), userFunctionParams);

--- a/runtime/src/test/java/com/fnproject/fn/runtime/ConfigurationMethodsTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/ConfigurationMethodsTest.java
@@ -16,6 +16,7 @@
 
 package com.fnproject.fn.runtime;
 
+import com.fnproject.fn.api.OutputEvent;
 import com.fnproject.fn.runtime.testfns.TestFnWithConfigurationMethods;
 import org.junit.Rule;
 import org.junit.Test;
@@ -84,7 +85,7 @@ public class ConfigurationMethodsTest {
 
         fn.thenRun(TestFnWithConfigurationMethods.StaticTargetInstanceConfiguration.class, "echo");
 
-        assertThat(fn.getOutputs()).isEmpty();
+        assertThat(fn.getOutputs()).hasSize(1).allSatisfy(testOutput -> assertThat(testOutput.getStatus()).isEqualTo(OutputEvent.Status.FunctionError));
         assertThat(fn.getStdErrAsString()).startsWith(expectedMessage);
         assertThat(fn.exitStatus()).isEqualTo(2);
     }
@@ -143,7 +144,7 @@ public class ConfigurationMethodsTest {
     }
 
     @Test
-    public  void shouldReturnSetConfigParameterWhenProvided() {
+    public void shouldReturnSetConfigParameterWhenProvided() {
         String value = "value";
         fn.setConfig("PARAM", value);
         fn.givenEvent().enqueue();
@@ -163,7 +164,9 @@ public class ConfigurationMethodsTest {
                 "'config'" +
                 " does not have a void return type";
 
-        assertThat(fn.getOutputs()).isEmpty();
+        assertThat(fn.getOutputs()).hasSize(1).allSatisfy(testOutput -> {
+            assertThat(testOutput.getStatus()).isEqualTo(OutputEvent.Status.FunctionError);
+        });
         assertThat(fn.getStdErrAsString()).startsWith(expectedMessage);
         assertThat(fn.exitStatus()).isEqualTo(2);
     }

--- a/runtime/src/test/java/com/fnproject/fn/runtime/FunctionConstructionTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/FunctionConstructionTest.java
@@ -16,7 +16,9 @@
 
 package com.fnproject.fn.runtime;
 
+import com.fnproject.fn.api.OutputEvent;
 import com.fnproject.fn.runtime.testfns.TestFnConstructors;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,6 +61,7 @@ public class FunctionConstructionTest {
         fn.givenEvent().enqueue();
         fn.thenRun(TestFnConstructors.BadConstructorNotAccessible.class, "invoke");
         assertThat(fn.exitStatus()).isEqualTo(2);
+        assertThat(fn.getOutputs()).hasSize(1).allSatisfy(testOutput -> Assertions.assertThat(testOutput.getStatus()).isEqualTo(OutputEvent.Status.FunctionError));
         assertThat(fn.getStdErrAsString()).contains("cannot be instantiated as it has no public constructors");
     }
 
@@ -67,6 +70,7 @@ public class FunctionConstructionTest {
         fn.givenEvent().enqueue();
         fn.thenRun(TestFnConstructors.BadConstructorTooManyArgs.class, "invoke");
         assertThat(fn.exitStatus()).isEqualTo(2);
+        assertThat(fn.getOutputs()).hasSize(1).allSatisfy(testOutput -> Assertions.assertThat(testOutput.getStatus()).isEqualTo(OutputEvent.Status.FunctionError));
         assertThat(fn.getStdErrAsString()).contains("cannot be instantiated as its constructor takes more than one argument");
     }
 
@@ -75,6 +79,7 @@ public class FunctionConstructionTest {
         fn.givenEvent().enqueue();
         fn.thenRun(TestFnConstructors.BadConstructorAmbiguousConstructors.class, "invoke");
         assertThat(fn.exitStatus()).isEqualTo(2);
+        assertThat(fn.getOutputs()).hasSize(1).allSatisfy(testOutput -> Assertions.assertThat(testOutput.getStatus()).isEqualTo(OutputEvent.Status.FunctionError));
         assertThat(fn.getStdErrAsString()).contains("cannot be instantiated as it has multiple public constructors");
     }
 
@@ -83,6 +88,7 @@ public class FunctionConstructionTest {
         fn.givenEvent().enqueue();
         fn.thenRun(TestFnConstructors.BadConstructorThrowsException.class, "invoke");
         assertThat(fn.exitStatus()).isEqualTo(2);
+        assertThat(fn.getOutputs()).hasSize(1).allSatisfy(testOutput -> Assertions.assertThat(testOutput.getStatus()).isEqualTo(OutputEvent.Status.FunctionError));
         assertThat(fn.getStdErrAsString()).contains("An error occurred in the function constructor while instantiating class");
     }
 
@@ -91,6 +97,7 @@ public class FunctionConstructionTest {
         fn.givenEvent().enqueue();
         fn.thenRun(TestFnConstructors.BadConstructorUnrecognisedArg.class, "invoke");
         assertThat(fn.exitStatus()).isEqualTo(2);
+        assertThat(fn.getOutputs()).hasSize(1).allSatisfy(testOutput -> Assertions.assertThat(testOutput.getStatus()).isEqualTo(OutputEvent.Status.FunctionError));
         assertThat(fn.getStdErrAsString()).contains("cannot be instantiated as its constructor takes an unrecognized argument of type int");
     }
 
@@ -100,6 +107,7 @@ public class FunctionConstructionTest {
         fn.givenEvent().enqueue();
         fn.thenRun(TestFnConstructors.NonStaticInnerClass.class, "invoke");
         assertThat(fn.exitStatus()).isEqualTo(2);
+        assertThat(fn.getOutputs()).hasSize(1).allSatisfy(testOutput -> Assertions.assertThat(testOutput.getStatus()).isEqualTo(OutputEvent.Status.FunctionError));
         assertThat(fn.getStdErrAsString()).contains("cannot be instantiated as it is a non-static inner class");
     }
 }


### PR DESCRIPTION
Logs are sometimes not emitted for failures that occur within function initialization - this means that errors related to: 

* Function construction 
* Incorrect handler methods 
* Non-existant classes

Are not logged 

It think this is caused by two things: 
* the  log framing tag is not emitted until after the method has been initalized, after these errors may have occured. 
*  The JVM is shut down before the logs are flushed to docker 

This change defers initialization of the function Runtime context until the first event is received, ensuring that initialization errors are logged, and also moves log framing out of the method invoker and up to the function entrypoint. 

This also keeps the JVM alive if there is an error in initalization. 

