### PR TITLE
Extend Jackson feature to match and add reflection for classes

### DIFF
--- a/experimental-native-image-support/src/test/java/com/fnproject/fn/nativeimagesupport/JacksonFeatureTest.java
+++ b/experimental-native-image-support/src/test/java/com/fnproject/fn/nativeimagesupport/JacksonFeatureTest.java
@@ -21,11 +21,11 @@ public class JacksonFeatureTest {
 
     @Test
     public void shouldWalkAnnotations() {
-        assertThat(JacksonFeature.expandAnnotationReferencesForClass(AbstractBase.class)).containsExactly(ConcreteSubType.class);
-        assertThat(JacksonFeature.expandAnnotationReferencesForClass(InterfaceBase.class)).containsExactly(InterfaceImpl.class);
-        assertThat(JacksonFeature.expandAnnotationReferencesForClass(UsesJacksonFeatures.class)).containsExactly(UsesJacksonFeatures.Builder.class);
-        assertThat(JacksonFeature.expandAnnotationReferencesForClass(AnnotationsOnFields.class)).containsExactly(BigInteger.class);
-        assertThat(JacksonFeature.expandAnnotationReferencesForClass(AnnotationsOnMethods.class)).containsExactly(BigInteger.class);
+        assertThat(JacksonFeature.expandClassesToMarkForReflection(AbstractBase.class)).containsExactly(AbstractBase.class,ConcreteSubType.class);
+        assertThat(JacksonFeature.expandClassesToMarkForReflection(InterfaceBase.class)).containsExactly(InterfaceBase.class,InterfaceImpl.class);
+        assertThat(JacksonFeature.expandClassesToMarkForReflection(UsesJacksonFeatures.class)).containsExactly(UsesJacksonFeatures.class,UsesJacksonFeatures.Builder.class);
+        assertThat(JacksonFeature.expandClassesToMarkForReflection(AnnotationsOnFields.class)).containsExactly(AnnotationsOnFields.class,BigInteger.class);
+        assertThat(JacksonFeature.expandClassesToMarkForReflection(AnnotationsOnMethods.class)).containsExactly(AnnotationsOnMethods.class,BigInteger.class);
     }
 
 

--- a/images/init-native/Dockerfile
+++ b/images/init-native/Dockerfile
@@ -29,8 +29,6 @@ COPY --from=build /function/target/*.jar target/
 RUN /usr/bin/native-image \
     --static \
     --no-fallback \
-    --initialize-at-build-time= \
-    --initialize-at-run-time=com.fnproject.fn.runtime.ntv.UnixSocketNative \
     --allow-incomplete-classpath \
     --enable-all-security-services \
     --enable-url-protocols=https,http \


### PR DESCRIPTION
This extends Jackson reflection matching to include adding reflective access for all classes that _have_ Jackson annotations as well as the classes they reference . 

This also changes the default Class Initializer behaviour default from "all at build time" to "all at runtime except for known-safe classes". This resolves an issue where a customer initializing config in static initializers were getting unexpected results as the fields were being initialized to null at compile time rather than getting their function config variables. 

Example output for an OCI client app: 

```
[func:26]    classlist:   4,363.04 ms,  1.19 GB
JacksonFeature: FnProject experimental Jackson feature loaded
JacksonFeature: Graal native image support is *experimental* it may not be stable and there may be cases where it does not work as expected
[func:26]        (cap):     725.76 ms,  1.19 GB
WARNING: Could not resolve org.slf4j.impl.StaticLoggerBinder for reflection configuration. Reason: java.lang.ClassNotFoundException: org.slf4j.impl.StaticLoggerBinder.
[func:26]        setup:   2,854.07 ms,  1.19 GB
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.CalendarSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.DateSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.SqlDateSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.NumberSerializers$IntLikeSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.NumberSerializers$LongSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.NumberSerializers$FloatSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.NumberSerializers$DoubleSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.NumberSerializers$ShortSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.NumberSerializers$IntegerSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.BooleanSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.StringSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.NumberSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.EnumSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.SqlTimeSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.StdArraySerializers$CharArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.ByteArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.IterableSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.impl.IteratorSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.impl.MapEntrySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.StdArraySerializers$DoubleArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.impl.StringArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.StdArraySerializers$BooleanArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.ObjectArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.StdArraySerializers$IntArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.StdArraySerializers$FloatArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.StdArraySerializers$ShortArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.StdArraySerializers$LongArraySerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.MapSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.impl.IndexedStringListSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.impl.StringCollectionSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.ToStringSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.NullSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.TokenBufferSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.SerializableSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.std.JsonValueSerializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.JsonMappingException$Reference
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.ser.BeanPropertyWriter
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.JsonMappingException
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$IntegerDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$BooleanDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$LongDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$ByteDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$DoubleDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$ShortDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$FloatDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$CharacterDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.EnumDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.DateDeserializers$CalendarDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.DateDeserializers$DateDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.TokenBufferDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.StringDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$NumberDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$BigDecimalDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.NumberDeserializers$BigIntegerDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers$IntDeser
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers$LongDeser
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers$ByteDeser
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers$ShortDeser
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers$FloatDeser
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers$DoubleDeser
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers$BooleanDeser
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.PrimitiveArrayDeserializers$CharDeser
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.StringArrayDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer$Vanilla
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.MapDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.MapEntryDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.CollectionDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.UntypedObjectDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.StdValueInstantiator
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer$StringKD
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.deser.std.StdKeyDeserializer$EnumKD
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.requests.BmcRequest
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.CreateBucketDetails
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.CreateBucketDetails$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.CreateBucketDetails$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.ObjectSummary
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.ObjectSummary$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.BucketSummary
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.BucketSummary$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.Bucket
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.Bucket$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.BucketSummary$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.ObjectSummary$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.Bucket$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.ListObjects
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.ListObjects$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.auth.internal.JWK
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.http.internal.ResponseHelper$ErrorCodeAndMessage
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.http.internal.ResponseHelper$ErrorCodeAndMessage$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.http.internal.ResponseHelper$ErrorCodeAndMessage$Builder
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.ListObjects$Builder
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatTypes
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat
JacksonFeature: adding extra Jackson annotated class com.fasterxml.jackson.databind.jsonschema.JsonSchema
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.ArchivalState
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.Bucket$PublicAccessType
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.Bucket$StorageTier
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.Bucket$Versioning
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.CreateBucketDetails$PublicAccessType
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.CreateBucketDetails$StorageTier
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.CreateBucketDetails$Versioning
JacksonFeature: adding extra Jackson annotated class com.oracle.bmc.objectstorage.model.StorageTier

```