### PR TITLE
Add Unix socket handling JNI library to runtime jar

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -99,6 +99,14 @@
                 <targetPath>${build.directory}/version-sources</targetPath>
                 <filtering>true</filtering>
             </resource>
+            <resource>
+                <directory>src/main/c/</directory>
+                <includes>
+                    <include>*.so</include>
+                </includes>
+                <filtering>false</filtering>
+                <targetPath>${build.directory}/classes/META-INF/com.fnproject.fn/runtime/native/</targetPath>
+            </resource>
         </resources>
         <plugins>
             <plugin>


### PR DESCRIPTION
This bundles the UDS socket JNI library within the runtime jar artifact 

This allows users building custom runtimes to fetch and extract this library on build  (without fetching the docker image) when building home-grown runtime images. 