### PR TITLE
Add support for Oracle Cloud Infrastructure tracing solution by providing a tracing context

### DIFF
--- a/api/src/main/api/snapshot.sigfile
+++ b/api/src/main/api/snapshot.sigfile
@@ -134,6 +134,8 @@ meth public abstract <%0 extends java.lang.Object> java.util.Optional<{%%0}> get
 meth public abstract com.fnproject.fn.api.MethodWrapper getMethod()
 meth public abstract java.lang.String getAppID()
 meth public abstract java.lang.String getFunctionID()
+meth public java.lang.String getAppName()
+meth public java.lang.String getFunctionName()
 meth public abstract java.util.List<com.fnproject.fn.api.InputCoercion> getInputCoercions(com.fnproject.fn.api.MethodWrapper,int)
 meth public abstract java.util.List<com.fnproject.fn.api.OutputCoercion> getOutputCoercions(java.lang.reflect.Method)
 meth public abstract java.util.Map<java.lang.String,java.lang.String> getConfiguration()
@@ -181,6 +183,20 @@ meth public abstract QueryParameters getQueryParameters()
 meth public abstract void addResponseHeader(String key, String value)
 meth public abstract void setResponseHeader(String key, String v1, String... vs)
 meth public abstract void setStatusCode(int code)
+
+CLSS public abstract interface com.fnproject.fn.api.tracing.TracingContext
+meth public abstract InvocationContext getInvocationContext()
+meth public abstract RuntimeContext getRuntimeContext()
+meth public abstract java.lang.String getServiceName()
+meth public abstract java.lang.String getTraceCollectorURL()
+meth public abstract java.lang.String getTraceId()
+meth public abstract java.lang.String getSpanId()
+meth public abstract java.lang.String getParentSpanId()
+meth public abstract java.lang.Boolean isSampled()
+meth public abstract java.lang.String getFlags()
+meth public abstract java.lang.Boolean isTracingEnabled()
+meth public abstract java.lang.String getAppName()
+meth public abstract java.lang.String getFunctionName()
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/api/src/main/java/com/fnproject/fn/api/RuntimeContext.java
+++ b/api/src/main/java/com/fnproject/fn/api/RuntimeContext.java
@@ -44,6 +44,24 @@ public interface RuntimeContext {
     String getFunctionID();
 
     /**
+     * The user-friendly name of the application associated with this function,
+     * if present; defaulted to the application ID for backwards compatibility
+     * @return an application name
+     */
+    default public String getAppName() {
+        return getAppID();
+    }
+
+    /**
+     * The user-friendly name of the function, if present; defaulted to the
+     * function ID for backwards compatibility
+     * @return a function name
+     */
+    default public String getFunctionName() {
+        return getFunctionID();
+    }
+
+    /**
      * Create an instance of the user specified class on which the target function to invoke is declared.
      *
      * @return new instance of class containing the target function

--- a/api/src/main/java/com/fnproject/fn/api/tracing/TracingContext.java
+++ b/api/src/main/java/com/fnproject/fn/api/tracing/TracingContext.java
@@ -1,0 +1,101 @@
+package com.fnproject.fn.api.tracing;
+
+import com.fnproject.fn.api.InvocationContext;
+import com.fnproject.fn.api.RuntimeContext;
+
+public interface TracingContext {
+
+    /**
+     * Returns the underlying invocation context behind this Tracing context
+     *
+     * @return an invocation context related to this function
+     */
+    InvocationContext getInvocationContext();
+
+    /**
+     * Returns the {@link RuntimeContext} associated with this invocation context
+     *
+     * @return a runtime context
+     */
+    RuntimeContext getRuntimeContext();
+
+    /**
+     * Returns true if tracing is enabled for this function invocation
+     *
+     * @return whether tracing is enabled
+     */
+    Boolean isTracingEnabled();
+
+    /**
+     * Returns the user-friendly name of the application associated with the
+     * function; shorthand for getRuntimeContext().getAppName()
+     *
+     * @return the user-friendly name of the application associated with the
+     * function
+     */
+    String getAppName();
+
+    /**
+     * Returns the user-friendly name of the function; shorthand for
+     * getRuntimeContext().getFunctionName()
+     *
+     * @return the user-friendly name of the function
+     */
+    String getFunctionName();
+
+    /**
+     * Returns a standard constructed "service name" to be used in tracing
+     * libraries to identify the function
+     *
+     * @return a standard constructed "service name"
+     */
+    String getServiceName();
+
+    /**
+     * Returns the URL to be used in tracing libraries as the destination for
+     * the tracing data
+     *
+     * @return a string containing the trace collector URL
+     */
+    String getTraceCollectorURL();
+
+    /**
+     * Returns the current trace ID as extracted from Zipkin B3 headers if they
+     * are present on the request
+     *
+     * @return the trace ID as a string
+     */
+    String getTraceId();
+
+    /**
+     * Returns the current span ID as extracted from Zipkin B3 headers if they
+     * are present on the request
+     *
+     * @return the span ID as a string
+     */
+    String getSpanId();
+
+    /**
+     * Returns the parent span ID as extracted from Zipkin B3 headers if they
+     * are present on the request
+     *
+     * @return the parent span ID as a string
+     */
+    String getParentSpanId();
+
+    /**
+     * Returns the value of the Sampled header of the Zipkin B3 headers if they
+     * are present on the request
+     *
+     * @return true if sampling is enabled for the request
+     */
+    Boolean isSampled();
+
+    /**
+     * Returns the value of the Flags header of the Zipkin B3 headers if they
+     * are present on the request
+     *
+     * @return the verbatim value of the X-B3-Flags header
+     */
+    String getFlags();
+}

--- a/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/EntryPoint.java
@@ -279,7 +279,7 @@ public class EntryPoint {
      * any headers that were added to env. Headers are identified as being variables prepended with 'HEADER_'.
      */
     private Map<String, String> excludeInternalConfigAndHeaders(Map<String, String> env) {
-        Set<String> nonConfigEnvKeys = new HashSet<>(Arrays.asList("fn_app_name", "fn_path", "fn_method", "fn_request_url",
+        Set<String> nonConfigEnvKeys = new HashSet<>(Arrays.asList("fn_path", "fn_method", "fn_request_url",
             "fn_format", "content-length", "fn_call_id"));
         Map<String, String> config = new HashMap<>();
         for (Map.Entry<String, String> entry : env.entrySet()) {

--- a/runtime/src/main/java/com/fnproject/fn/runtime/FunctionRuntimeContext.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/FunctionRuntimeContext.java
@@ -62,6 +62,16 @@ public class FunctionRuntimeContext implements RuntimeContext {
     }
 
     @Override
+    public String getAppName() {
+        return config.getOrDefault("FN_APP_NAME", "");
+    }
+
+    @Override
+    public String getFunctionName() {
+        return config.getOrDefault("FN_FN_NAME", "");
+    }
+
+    @Override
     public Optional<Object> getInvokeInstance() {
         if (!Modifier.isStatic(getMethod().getTargetMethod().getModifiers())) {
             if (instance == null) {

--- a/runtime/src/main/java/com/fnproject/fn/runtime/coercion/ContextCoercion.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/coercion/ContextCoercion.java
@@ -18,7 +18,9 @@ package com.fnproject.fn.runtime.coercion;
 
 import com.fnproject.fn.api.*;
 import com.fnproject.fn.api.httpgateway.HTTPGatewayContext;
+import com.fnproject.fn.api.tracing.TracingContext;
 import com.fnproject.fn.runtime.httpgateway.FunctionHTTPGatewayContext;
+import com.fnproject.fn.runtime.tracing.OCITracingContext;
 
 import java.util.Optional;
 
@@ -37,6 +39,8 @@ public class ContextCoercion implements InputCoercion<Object> {
             return Optional.of(currentContext);
         } else if (paramClass.equals(HTTPGatewayContext.class)) {
             return Optional.of(new FunctionHTTPGatewayContext(currentContext));
+        } else if (paramClass.equals(TracingContext.class)) {
+            return Optional.of(new OCITracingContext(currentContext, currentContext.getRuntimeContext()));
         } else {
             return Optional.empty();
         }

--- a/runtime/src/main/java/com/fnproject/fn/runtime/tracing/OCITracingContext.java
+++ b/runtime/src/main/java/com/fnproject/fn/runtime/tracing/OCITracingContext.java
@@ -1,0 +1,117 @@
+package com.fnproject.fn.runtime.tracing;
+
+import com.fnproject.fn.api.Headers;
+import com.fnproject.fn.api.InvocationContext;
+import com.fnproject.fn.api.RuntimeContext;
+import com.fnproject.fn.api.tracing.TracingContext;
+
+public class OCITracingContext implements TracingContext {
+    private final InvocationContext invocationContext;
+    private final RuntimeContext runtimeContext;
+    private String traceCollectorURL;
+    private String traceId;
+    private String spanId;
+    private String parentSpanId;
+    private Boolean sampled = true;
+    private String flags;
+    private Boolean tracingEnabled;
+    private String appName;
+    private String fnName;
+
+    public OCITracingContext(InvocationContext invocationContext, RuntimeContext runtimeContext) {
+        this.invocationContext = invocationContext;
+        this.runtimeContext = runtimeContext;
+
+        configure(runtimeContext);
+
+        if(tracingEnabled)
+            configure(invocationContext.getRequestHeaders());
+    }
+
+    private void configure(RuntimeContext runtimeContext) {
+        if(runtimeContext != null && runtimeContext.getConfigurationByKey("OCI_TRACE_COLLECTOR_URL").get() != null
+                && runtimeContext.getConfigurationByKey("OCI_TRACING_ENABLED").get() != null) {
+            this.traceCollectorURL = runtimeContext.getConfigurationByKey("OCI_TRACE_COLLECTOR_URL").get();
+            try {
+                Integer tracingEnabledAsInt = Integer.parseInt(runtimeContext.getConfigurationByKey("OCI_TRACING_ENABLED").get());
+                this.tracingEnabled = tracingEnabledAsInt != 0;
+            } catch(java.lang.NumberFormatException ex) {
+                this.tracingEnabled = false;
+            }
+            this.appName = runtimeContext.getAppName();
+            this.fnName = runtimeContext.getFunctionName();
+        }
+    }
+
+    private void configure(Headers headers) {
+        this.flags = headers.get("x-b3-flags").orElse("");
+        if (headers.get("x-b3-sampled").isPresent() && Integer.parseInt(headers.get("x-b3-sampled").get()) == 0) {
+            this.sampled = false;
+            return;
+        }
+        this.sampled = true;
+        this.traceId = headers.get("x-b3-traceid").orElse("");
+        this.spanId = headers.get("x-b3-spanid").orElse("");
+        this.parentSpanId = headers.get("x-b3-parentspanid").orElse("");
+    }
+
+    @Override
+    public InvocationContext getInvocationContext() {
+        return invocationContext;
+    }
+
+    @Override
+    public RuntimeContext getRuntimeContext() {
+        return runtimeContext;
+    }
+
+    @Override
+    public String getServiceName() {
+        return this.appName.toLowerCase() + "::" + this.fnName.toLowerCase();
+    }
+
+    @Override
+    public String getTraceCollectorURL() {
+        return traceCollectorURL;
+    }
+
+    @Override
+    public String getTraceId() {
+        return traceId;
+    }
+
+    @Override
+    public String getSpanId() {
+        return spanId;
+    }
+
+    @Override
+    public String getParentSpanId() {
+        return parentSpanId;
+    }
+
+    @Override
+    public Boolean isSampled() {
+        return sampled;
+    }
+
+    @Override
+    public String getFlags() {
+        return flags;
+    }
+
+    @Override
+    public Boolean isTracingEnabled() {
+        return tracingEnabled;
+    }
+
+    @Override
+    public String getAppName() {
+        return appName;
+    }
+
+    @Override
+    public String getFunctionName() {
+        return fnName;
+    }
+}

--- a/runtime/src/test/java/com/fnproject/fn/runtime/tracing/OCITracingContextTest.java
+++ b/runtime/src/test/java/com/fnproject/fn/runtime/tracing/OCITracingContextTest.java
@@ -1,0 +1,110 @@
+package com.fnproject.fn.runtime.tracing;
+
+import com.fnproject.fn.api.Headers;
+import com.fnproject.fn.api.InvocationContext;
+import com.fnproject.fn.api.MethodWrapper;
+import com.fnproject.fn.runtime.FunctionRuntimeContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OCITracingContextTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    InvocationContext ctxMock;
+
+    @Mock
+    FunctionRuntimeContext runtimeContextMock;
+
+    @Mock
+    MethodWrapper methodWrapperMock;
+
+    private Map<String, String> getConfig(Boolean enabled) {
+        Map<String, String> env = new HashMap<>();
+        env.put("FN_APP_NAME", "myapp");
+        env.put("FN_FN_NAME", "myFunction");
+        env.put("OCI_TRACE_COLLECTOR_URL", "tracingPath");
+        env.put("OCI_TRACING_ENABLED", enabled ? "1" : "0");
+        return Collections.unmodifiableMap(env);
+    }
+
+    @Test
+    public void configureRuntimeContext() {
+        Map<String, String> config = getConfig(false);
+        runtimeContextMock = new FunctionRuntimeContext(methodWrapperMock, config);
+
+        OCITracingContext tracingContext = new OCITracingContext(ctxMock, runtimeContextMock);
+        assertThat(tracingContext.isTracingEnabled()).isEqualTo(false);
+        assertThat(tracingContext.getAppName()).isEqualToIgnoringCase("myapp");
+        assertThat(tracingContext.getFunctionName()).isEqualToIgnoringCase("myFunction");
+        assertThat(tracingContext.getTraceCollectorURL()).isEqualToIgnoringCase("tracingPath");
+    }
+
+    @Test
+    public void getServiceName() {
+        Map<String, String> config = getConfig(false);
+        runtimeContextMock = new FunctionRuntimeContext(methodWrapperMock, config);
+
+        OCITracingContext tracingContext = new OCITracingContext(ctxMock, runtimeContextMock);
+        assertThat(tracingContext.getServiceName()).isEqualToIgnoringCase("myapp::myFunction");
+    }
+
+    @Test
+    public void shouldAbleToConfigureWithNoHeaderData() {
+        Map<String, String> config = getConfig(true);
+        runtimeContextMock = new FunctionRuntimeContext(methodWrapperMock, config);
+        Mockito.when(ctxMock.getRequestHeaders()).thenReturn(Headers.emptyHeaders());
+
+        OCITracingContext tracingContext = new OCITracingContext(ctxMock, runtimeContextMock);
+        assertThat(tracingContext.isSampled()).isEqualTo(true);
+        assertThat(tracingContext.getTraceId()).isEmpty();
+        assertThat(tracingContext.getSpanId()).isEmpty();
+        assertThat(tracingContext.getParentSpanId()).isEmpty();
+    }
+
+    @Test
+    public void shouldAbleToConfigureWithHeaderDataNotSampled() {
+        Map<String, String> config = getConfig(true);
+        runtimeContextMock = new FunctionRuntimeContext(methodWrapperMock, config);
+        Map<String, String> headerData = new HashMap();
+        headerData.put("x-b3-sampled","0");
+        Headers headers = Headers.fromMap(headerData);
+        Mockito.when(ctxMock.getRequestHeaders()).thenReturn(headers);
+
+        OCITracingContext tracingContext = new OCITracingContext(ctxMock, runtimeContextMock);
+        assertThat(tracingContext.isSampled()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldAbleToConfigureWithHeaderData() {
+        Map<String, String> config = getConfig(true);
+        runtimeContextMock = new FunctionRuntimeContext(methodWrapperMock, config);
+        Map<String, String> headerData = new HashMap();
+        headerData.put("x-b3-sampled","1");
+        headerData.put("x-b3-flags","<implementation-specific data>");
+        headerData.put("x-b3-traceid","213454321432");
+        headerData.put("x-b3-spanid","244342r343");
+        headerData.put("x-b3-parentspanid","32142r231242");
+        Headers headers = Headers.fromMap(headerData);
+        Mockito.when(ctxMock.getRequestHeaders()).thenReturn(headers);
+
+        OCITracingContext tracingContext = new OCITracingContext(ctxMock, runtimeContextMock);
+        assertThat(tracingContext.isSampled()).isEqualTo(true);
+        assertThat(tracingContext.getTraceId()).isEqualTo("213454321432");
+        assertThat(tracingContext.getSpanId()).isEqualTo("244342r343");
+        assertThat(tracingContext.getParentSpanId()).isEqualTo("32142r231242");
+        assertThat(tracingContext.getFlags()).isEqualTo("<implementation-specific data>");
+    }
+}


### PR DESCRIPTION
**Overview**
Oracle Functions will soon release a feature providing an integration with the Oracle Application Performance Monitoring (APM) service. This service supports the sending of Zipkin formatted tracing data to a collector endpoint.

The service will provide the function code with data which includes:
- A boolean flag specifying whether the tracing integration is enabled for the function invocation
- A trace collector URL that can be used to configure Zipkin so that tracing data is sent there
- The "B3" formatted headers specifying the originating trace ID and span IDs (as specified by Zipkin)

This information is accessible by the function code in a Tracing Context provided by the FDK.

This change has no effect on existing functions, except that the keys "OCI_TRACING_ENABLED" and "OCI_TRACE_COLLECTOR_URL" are now reserved for this tracing integration and cannot be used for function configuration.

**FDK Specific Changes**
This change adds a TracingContext interface that users can use as a parameter of their function (much like the HTTPGatewayContext) to have access to the configuration data that Zipkin would need (i.e. a collector URL) and the headers data involved with tracing (for Zipkin, the "B3 Headers").

Once the Oracle Functions integration with APM is complete, users will be able to enable tracing for their functions and in that case the TracingContext will report isTracingEnabled() == true and will return the right data for each of its methods.