### PR TITLE
CVE-2022-42003: bump jackson version to 2.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <assertj-core.version>3.21.0</assertj-core.version>
         <commons-io.version>2.11.0</commons-io.version>
         <httpcore.version>4.4.14</httpcore.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.14.2</jackson.version>
         <jacoco.version>0.8.1</jacoco.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Details available [here](https://nvd.nist.gov/vuln/detail/CVE-2022-42003).